### PR TITLE
fix(WOR-TSK-134): replace wildcard version with explicit libgit2-sys version

### DIFF
--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -32,7 +32,7 @@ git2 = { version = "0.20", features = [
   "vendored-libgit2",
   "vendored-openssl",
 ] }
-libgit2-sys = { version = "*", features = [
+libgit2-sys = { version = "0.18", features = [
   "ssh",
   "https",
   "vendored",


### PR DESCRIPTION


Fix crates.io publish error by replacing wildcard (*) version constraint with explicit version for libgit2-sys dependency.

Error from crates.io:
- wildcard (`*`) dependency constraints are not allowed on crates.io
- Crate with this problem: libgit2-sys

Solution:
- Change libgit2-sys version from "*" to "0.18"
- Version 0.18 is compatible with git2 v0.20

Verification:
- Build: ✓ Success (0.49s)

This allows sublime_git_tools to be published to crates.io successfully.