### PR TITLE
chore: release v0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1064,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade6dfcba0dfb62ad59e59e7241ec8912af34fd29e0e743e3db992bd278e8b65"
+checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
  "console",
  "portable-atomic",
@@ -2110,7 +2110,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sublime_cli_tools"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "sublime_git_tools"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "sublime_pkg_tools"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "sublime_standard_tools"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.3"
+version = "0.0.4"
 authors = ["WebSublime"]
 edition = "2024"
 rust-version = "1.90.0"
@@ -12,10 +12,10 @@ repository = "https://github.com/websublime/workspace-tools"
 
 [workspace.dependencies]
 # Internal crates
-sublime_standard_tools = { version = "0.0.3", path = "crates/standard" }
-sublime_git_tools = { version = "0.0.3", path = "crates/git" }
-sublime_pkg_tools = { version = "0.0.3", path = "crates/pkg" }
-sublime_cli_tools = { version = "0.0.3", path = "crates/cli" }
+sublime_standard_tools = { version = "0.0.4", path = "crates/standard" }
+sublime_git_tools = { version = "0.0.4", path = "crates/git" }
+sublime_pkg_tools = { version = "0.0.4", path = "crates/pkg" }
+sublime_cli_tools = { version = "0.0.4", path = "crates/cli" }
 
 # Core dependencies
 async-trait = "0.1.74"

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.0.4 - 2025-11-11
+
+<!-- Made with ❤️ by WebSublime -->
+
 ## 0.0.3 - 2025-11-11
 
 ### Documentation

--- a/crates/git/CHANGELOG.md
+++ b/crates/git/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.0.4 - 2025-11-11
+
+<!-- Made with ❤️ by WebSublime -->
+
 ## 0.0.3 - 2025-11-11
 
 <!-- Made with ❤️ by WebSublime -->

--- a/crates/pkg/CHANGELOG.md
+++ b/crates/pkg/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.0.4 - 2025-11-11
+
+### Bug Fixes
+
+#### WOR-TSK-140
+
+- Add support for _auth authentication in .npmrc files ([#17](https://github.com/websublime/workspace-tools/pull/17))
+
+<!-- Made with ❤️ by WebSublime -->
+
 ## 0.0.3 - 2025-11-11
 
 <!-- Made with ❤️ by WebSublime -->

--- a/crates/standard/CHANGELOG.md
+++ b/crates/standard/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.0.4 - 2025-11-11
+
+<!-- Made with ❤️ by WebSublime -->
+
 ## 0.0.3 - 2025-11-11
 
 <!-- Made with ❤️ by WebSublime -->


### PR DESCRIPTION



## 🤖 New release

* `sublime_git_tools`: 0.0.3 -> 0.0.4
* `sublime_standard_tools`: 0.0.3 -> 0.0.4
* `sublime_pkg_tools`: 0.0.3 -> 0.0.4
* `sublime_cli_tools`: 0.0.3 -> 0.0.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `sublime_git_tools`

<blockquote>

## 0.0.4 - 2025-11-11

<!-- Made with ❤️ by WebSublime -->
</blockquote>

## `sublime_standard_tools`

<blockquote>

## 0.0.4 - 2025-11-11

<!-- Made with ❤️ by WebSublime -->
</blockquote>

## `sublime_pkg_tools`

<blockquote>

## 0.0.4 - 2025-11-11

### Bug Fixes

#### WOR-TSK-140

- Add support for _auth authentication in .npmrc files ([#17](https://github.com/websublime/workspace-tools/pull/17))

<!-- Made with ❤️ by WebSublime -->
</blockquote>

## `sublime_cli_tools`

<blockquote>

## 0.0.4 - 2025-11-11

<!-- Made with ❤️ by WebSublime -->
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).