### PR TITLE
chore: release v0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.22"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
 dependencies = [
  "cc",
  "libc",
@@ -2110,7 +2110,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sublime_cli_tools"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "sublime_git_tools"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "sublime_pkg_tools"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "sublime_standard_tools"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.4"
+version = "0.0.5"
 authors = ["WebSublime"]
 edition = "2024"
 rust-version = "1.90.0"
@@ -12,10 +12,10 @@ repository = "https://github.com/websublime/workspace-tools"
 
 [workspace.dependencies]
 # Internal crates
-sublime_standard_tools = { version = "0.0.4", path = "crates/standard" }
-sublime_git_tools = { version = "0.0.4", path = "crates/git" }
-sublime_pkg_tools = { version = "0.0.4", path = "crates/pkg" }
-sublime_cli_tools = { version = "0.0.4", path = "crates/cli" }
+sublime_standard_tools = { version = "0.0.5", path = "crates/standard" }
+sublime_git_tools = { version = "0.0.5", path = "crates/git" }
+sublime_pkg_tools = { version = "0.0.5", path = "crates/pkg" }
+sublime_cli_tools = { version = "0.0.5", path = "crates/cli" }
 
 # Core dependencies
 async-trait = "0.1.74"

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.0.5 - 2025-11-12
+
+<!-- Made with ❤️ by WebSublime -->
+
 ## 0.0.4 - 2025-11-11
 
 <!-- Made with ❤️ by WebSublime -->

--- a/crates/git/CHANGELOG.md
+++ b/crates/git/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.0.5 - 2025-11-12
+
+<!-- Made with ❤️ by WebSublime -->
+
 ## 0.0.4 - 2025-11-11
 
 <!-- Made with ❤️ by WebSublime -->

--- a/crates/pkg/CHANGELOG.md
+++ b/crates/pkg/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.0.5 - 2025-11-12
+
+### Bug Fixes
+
+#### WOR-TSK-141
+
+- Refactor git hooks philosophy - pre-commit adds, post-commit validates ([#19](https://github.com/websublime/workspace-tools/pull/19))
+
+<!-- Made with ❤️ by WebSublime -->
+
 ## 0.0.4 - 2025-11-11
 
 ### Bug Fixes

--- a/crates/standard/CHANGELOG.md
+++ b/crates/standard/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.0.5 - 2025-11-12
+
+<!-- Made with ❤️ by WebSublime -->
+
 ## 0.0.4 - 2025-11-11
 
 <!-- Made with ❤️ by WebSublime -->


### PR DESCRIPTION



## 🤖 New release

* `sublime_git_tools`: 0.0.4 -> 0.0.5
* `sublime_standard_tools`: 0.0.4 -> 0.0.5
* `sublime_pkg_tools`: 0.0.4 -> 0.0.5
* `sublime_cli_tools`: 0.0.4 -> 0.0.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `sublime_git_tools`

<blockquote>

## 0.0.5 - 2025-11-12

<!-- Made with ❤️ by WebSublime -->
</blockquote>

## `sublime_standard_tools`

<blockquote>

## 0.0.5 - 2025-11-12

<!-- Made with ❤️ by WebSublime -->
</blockquote>

## `sublime_pkg_tools`

<blockquote>

## 0.0.5 - 2025-11-12

### Bug Fixes

#### WOR-TSK-141

- Refactor git hooks philosophy - pre-commit adds, post-commit validates ([#19](https://github.com/websublime/workspace-tools/pull/19))

<!-- Made with ❤️ by WebSublime -->
</blockquote>

## `sublime_cli_tools`

<blockquote>

## 0.0.5 - 2025-11-12

<!-- Made with ❤️ by WebSublime -->
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).