### PR TITLE
fix(WOR-TSK-148): resolve branch name detection in detached HEAD state for CI/CD environments

### DIFF
--- a/crates/git/src/env.rs
+++ b/crates/git/src/env.rs
@@ -1,0 +1,361 @@
+//! Environment variable abstraction for testability
+//!
+//! This module provides traits and implementations for accessing environment variables,
+//! enabling dependency injection and facilitating testing of code that depends on
+//! environment state.
+//!
+//! # What
+//!
+//! Provides the `EnvProvider` trait to abstract environment variable access, along with
+//! concrete implementations for production and testing scenarios.
+//!
+//! # How
+//!
+//! - `EnvProvider` trait: Defines the interface for environment variable access
+//! - `SystemEnvProvider`: Production implementation using `std::env::var()`
+//! - `MockEnvProvider`: Test implementation using a configurable HashMap
+//!
+//! # Why
+//!
+//! Environment variables are global mutable state that cannot be reliably controlled
+//! in tests, especially when:
+//! - Tests run in parallel
+//! - Running in CI/CD environments with pre-set environment variables
+//! - Multiple tests need different environment configurations
+//!
+//! This abstraction enables clean, isolated testing without unsafe global state modification.
+//!
+//! # Examples
+//!
+//! ## Production Usage
+//!
+//! ```rust
+//! use sublime_git_tools::env::{EnvProvider, SystemEnvProvider};
+//! use std::sync::Arc;
+//!
+//! let env = Arc::new(SystemEnvProvider);
+//! match env.var("HOME") {
+//!     Ok(home) => println!("Home directory: {}", home),
+//!     Err(_) => println!("HOME not set"),
+//! }
+//! ```
+//!
+//! ## Testing Usage
+//!
+//! ```rust
+//! use sublime_git_tools::env::{EnvProvider, MockEnvProvider};
+//! use std::sync::Arc;
+//!
+//! let env = Arc::new(
+//!     MockEnvProvider::new()
+//!         .with_var("GITHUB_REF_NAME", "feature/test-branch")
+//!         .with_var("CI", "true")
+//! );
+//!
+//! assert_eq!(env.var("GITHUB_REF_NAME").unwrap(), "feature/test-branch");
+//! assert_eq!(env.var("CI").unwrap(), "true");
+//! assert!(env.var("NOT_SET").is_err());
+//! ```
+
+use std::env::VarError;
+
+#[cfg(test)]
+use std::collections::HashMap;
+
+/// Trait for accessing environment variables
+///
+/// This trait abstracts environment variable access to enable testing of code
+/// that depends on environment state without modifying global process state.
+///
+/// Implementations must be thread-safe (`Send + Sync`) to allow use across
+/// multiple threads and in concurrent testing scenarios.
+///
+/// # Examples
+///
+/// ```rust
+/// use sublime_git_tools::env::{EnvProvider, SystemEnvProvider};
+///
+/// let env = SystemEnvProvider;
+/// match env.var("PATH") {
+///     Ok(path) => println!("PATH: {}", path),
+///     Err(e) => println!("Error: {:?}", e),
+/// }
+/// ```
+pub trait EnvProvider: Send + Sync {
+    /// Gets an environment variable by name
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The environment variable name to retrieve
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(String)` - The value of the environment variable
+    /// * `Err(VarError::NotPresent)` - Variable is not set
+    /// * `Err(VarError::NotUnicode(_))` - Variable contains invalid Unicode
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use sublime_git_tools::env::{EnvProvider, SystemEnvProvider};
+    ///
+    /// let env = SystemEnvProvider;
+    /// if let Ok(user) = env.var("USER") {
+    ///     println!("Current user: {}", user);
+    /// }
+    /// ```
+    fn var(&self, key: &str) -> Result<String, VarError>;
+}
+
+/// System environment provider using `std::env::var`
+///
+/// This is the production implementation that delegates to the standard library's
+/// environment variable access. It reads from the actual process environment.
+///
+/// # Thread Safety
+///
+/// This implementation is thread-safe and can be safely shared across threads.
+/// Reading environment variables in Rust is thread-safe, though writing to them
+/// requires unsafe code.
+///
+/// # Examples
+///
+/// ```rust
+/// use sublime_git_tools::env::{EnvProvider, SystemEnvProvider};
+/// use std::sync::Arc;
+///
+/// let env = Arc::new(SystemEnvProvider);
+/// let home = env.var("HOME").expect("HOME should be set");
+/// println!("Home directory: {}", home);
+/// ```
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemEnvProvider;
+
+impl EnvProvider for SystemEnvProvider {
+    fn var(&self, key: &str) -> Result<String, VarError> {
+        std::env::var(key)
+    }
+}
+
+/// Mock environment provider for testing
+///
+/// This implementation uses an internal HashMap to store environment variable
+/// values, allowing tests to create controlled, isolated environment configurations
+/// without modifying the global process state.
+///
+/// # Thread Safety
+///
+/// This implementation is thread-safe. Each instance has its own independent
+/// HashMap of variables, preventing interference between tests.
+///
+/// # Examples
+///
+/// ## Basic Usage
+///
+/// ```rust
+/// use sublime_git_tools::env::{EnvProvider, MockEnvProvider};
+///
+/// let env = MockEnvProvider::new()
+///     .with_var("GITHUB_REF_NAME", "main")
+///     .with_var("CI", "true");
+///
+/// assert_eq!(env.var("GITHUB_REF_NAME").unwrap(), "main");
+/// assert_eq!(env.var("CI").unwrap(), "true");
+/// assert!(env.var("NOT_SET").is_err());
+/// ```
+///
+/// ## Testing CI Environments
+///
+/// ```rust
+/// use sublime_git_tools::env::{EnvProvider, MockEnvProvider};
+///
+/// // Simulate GitHub Actions environment
+/// let github_env = MockEnvProvider::new()
+///     .with_var("GITHUB_ACTIONS", "true")
+///     .with_var("GITHUB_REF_NAME", "feature/new-feature")
+///     .with_var("GITHUB_HEAD_REF", "");
+///
+/// // Simulate GitLab CI environment
+/// let gitlab_env = MockEnvProvider::new()
+///     .with_var("CI", "true")
+///     .with_var("CI_COMMIT_REF_NAME", "develop");
+///
+/// assert_eq!(github_env.var("GITHUB_REF_NAME").unwrap(), "feature/new-feature");
+/// assert_eq!(gitlab_env.var("CI_COMMIT_REF_NAME").unwrap(), "develop");
+/// ```
+#[cfg(test)]
+#[derive(Debug, Clone, Default)]
+pub struct MockEnvProvider {
+    /// Internal storage for environment variable key-value pairs
+    vars: HashMap<String, String>,
+}
+
+#[cfg(test)]
+impl MockEnvProvider {
+    /// Creates a new empty mock environment provider
+    ///
+    /// # Returns
+    ///
+    /// A new `MockEnvProvider` with no environment variables set
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use sublime_git_tools::env::MockEnvProvider;
+    ///
+    /// let env = MockEnvProvider::new();
+    /// assert!(env.var("ANY_VAR").is_err());
+    /// ```
+    pub fn new() -> Self {
+        Self { vars: HashMap::new() }
+    }
+
+    /// Adds an environment variable to the mock provider
+    ///
+    /// This method uses a builder pattern, allowing method chaining to configure
+    /// multiple variables in a fluent style.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The environment variable name
+    /// * `value` - The environment variable value
+    ///
+    /// # Returns
+    ///
+    /// Self with the variable added, enabling method chaining
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use sublime_git_tools::env::{EnvProvider, MockEnvProvider};
+    ///
+    /// let env = MockEnvProvider::new()
+    ///     .with_var("VAR1", "value1")
+    ///     .with_var("VAR2", "value2")
+    ///     .with_var("VAR3", "value3");
+    ///
+    /// assert_eq!(env.var("VAR1").unwrap(), "value1");
+    /// assert_eq!(env.var("VAR2").unwrap(), "value2");
+    /// assert_eq!(env.var("VAR3").unwrap(), "value3");
+    /// ```
+    #[must_use]
+    pub fn with_var(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.vars.insert(key.into(), value.into());
+        self
+    }
+}
+
+#[cfg(test)]
+impl EnvProvider for MockEnvProvider {
+    fn var(&self, key: &str) -> Result<String, VarError> {
+        self.vars.get(key).cloned().ok_or(VarError::NotPresent)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_system_env_provider_reads_real_variables() {
+        let env = SystemEnvProvider;
+
+        // PATH should always exist
+        let result = env.var("PATH");
+        assert!(result.is_ok(), "PATH should be set in environment");
+        assert!(!result.unwrap().is_empty(), "PATH should not be empty");
+    }
+
+    #[test]
+    fn test_system_env_provider_returns_error_for_missing_variables() {
+        let env = SystemEnvProvider;
+
+        let result = env.var("THIS_VARIABLE_SHOULD_NOT_EXIST_12345");
+        assert!(result.is_err(), "Non-existent variable should return error");
+        assert!(
+            matches!(result.unwrap_err(), VarError::NotPresent),
+            "Error should be VarError::NotPresent"
+        );
+    }
+
+    #[test]
+    fn test_mock_env_provider_new_is_empty() {
+        let env = MockEnvProvider::new();
+
+        assert!(env.var("ANY_VAR").is_err(), "New mock provider should have no variables");
+    }
+
+    #[test]
+    fn test_mock_env_provider_with_var_single() {
+        let env = MockEnvProvider::new().with_var("TEST_VAR", "test_value");
+
+        assert_eq!(env.var("TEST_VAR").unwrap(), "test_value", "Should return configured value");
+        assert!(env.var("OTHER_VAR").is_err(), "Should return error for unconfigured variable");
+    }
+
+    #[test]
+    fn test_mock_env_provider_with_var_multiple() {
+        let env = MockEnvProvider::new()
+            .with_var("VAR1", "value1")
+            .with_var("VAR2", "value2")
+            .with_var("VAR3", "value3");
+
+        assert_eq!(env.var("VAR1").unwrap(), "value1");
+        assert_eq!(env.var("VAR2").unwrap(), "value2");
+        assert_eq!(env.var("VAR3").unwrap(), "value3");
+        assert!(env.var("VAR4").is_err());
+    }
+
+    #[test]
+    fn test_mock_env_provider_with_var_empty_value() {
+        let env = MockEnvProvider::new().with_var("EMPTY_VAR", "");
+
+        assert_eq!(env.var("EMPTY_VAR").unwrap(), "", "Should support empty string values");
+    }
+
+    #[test]
+    fn test_mock_env_provider_with_var_overwrite() {
+        let env = MockEnvProvider::new()
+            .with_var("TEST_VAR", "first_value")
+            .with_var("TEST_VAR", "second_value");
+
+        assert_eq!(
+            env.var("TEST_VAR").unwrap(),
+            "second_value",
+            "Later value should overwrite earlier value"
+        );
+    }
+
+    #[test]
+    fn test_mock_env_provider_ci_simulation() {
+        // Simulate GitHub Actions environment
+        let github_env = MockEnvProvider::new()
+            .with_var("GITHUB_ACTIONS", "true")
+            .with_var("GITHUB_REF_NAME", "feature/test-branch")
+            .with_var("GITHUB_HEAD_REF", "");
+
+        assert_eq!(github_env.var("GITHUB_ACTIONS").unwrap(), "true");
+        assert_eq!(github_env.var("GITHUB_REF_NAME").unwrap(), "feature/test-branch");
+        assert_eq!(github_env.var("GITHUB_HEAD_REF").unwrap(), "");
+
+        // Simulate GitLab CI environment
+        let gitlab_env =
+            MockEnvProvider::new().with_var("CI", "true").with_var("CI_COMMIT_REF_NAME", "develop");
+
+        assert_eq!(gitlab_env.var("CI").unwrap(), "true");
+        assert_eq!(gitlab_env.var("CI_COMMIT_REF_NAME").unwrap(), "develop");
+    }
+
+    #[test]
+    fn test_system_env_provider_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SystemEnvProvider>();
+    }
+
+    #[test]
+    fn test_mock_env_provider_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<MockEnvProvider>();
+    }
+}

--- a/crates/git/src/lib.rs
+++ b/crates/git/src/lib.rs
@@ -113,11 +113,16 @@
 #![deny(clippy::unimplemented)]
 #![deny(clippy::panic)]
 
+mod env;
 mod repo;
 mod types;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+pub use env::MockEnvProvider;
+pub use env::{EnvProvider, SystemEnvProvider};
 
 pub use types::{
     GitChangedFile, GitDiffStats, GitFileStatus, Repo, RepoCommit, RepoError, RepoTags,

--- a/crates/git/src/repo.rs
+++ b/crates/git/src/repo.rs
@@ -63,6 +63,7 @@ use git2::{
 use std::collections::HashMap;
 use std::fs::canonicalize;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::{GitChangedFile, GitFileStatus, Repo, RepoCommit, RepoError, RepoTags};
 
@@ -333,6 +334,45 @@ impl Repo {
     /// println!("Repository created at: {}", repo.get_repo_path().display());
     /// ```
     pub fn create(path: &str) -> Result<Self, RepoError> {
+        Self::create_with_env(path, Arc::new(crate::env::SystemEnvProvider))
+    }
+
+    /// Creates a new Git repository at the specified path with custom environment provider
+    ///
+    /// This method is primarily useful for testing scenarios where you need to control
+    /// environment variables without modifying the global process state.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path where the repository should be created
+    /// * `env` - Environment variable provider for dependency injection
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Self, RepoError>` - A new `Repo` instance or an error
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - The path cannot be canonicalized
+    /// - The directory cannot be created
+    /// - Git repository initialization fails
+    /// - The repository cannot be opened after creation
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sublime_git_tools::{Repo, SystemEnvProvider};
+    /// use std::sync::Arc;
+    ///
+    /// let repo = Repo::create_with_env("/tmp/new-repo", Arc::new(SystemEnvProvider))
+    ///     .expect("Failed to create repository");
+    /// println!("Repository created at: {}", repo.get_repo_path().display());
+    /// ```
+    pub fn create_with_env(
+        path: &str,
+        env: Arc<dyn crate::env::EnvProvider>,
+    ) -> Result<Self, RepoError> {
         let location = canonicalize_path(path)?;
         let location_buf = PathBuf::from(location);
 
@@ -344,7 +384,7 @@ impl Repo {
         .map_err(RepoError::CreateRepoFailure)?;
 
         // Just return the repo without making any commits
-        let result = Self { repo, local_path: location_buf };
+        let result = Self { repo, local_path: location_buf, env };
 
         // Now make the initial commit using our new instance
         result.make_initial_commit()?;
@@ -381,10 +421,51 @@ impl Repo {
     /// ```
     #[allow(clippy::arc_with_non_send_sync)]
     pub fn open(path: &str) -> Result<Self, RepoError> {
+        Self::open_with_env(path, Arc::new(crate::env::SystemEnvProvider))
+    }
+
+    /// Opens an existing Git repository at the specified path with custom environment provider
+    ///
+    /// This method is primarily useful for testing scenarios where you need to control
+    /// environment variables without modifying the global process state.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path to the existing repository
+    /// * `env` - Environment variable provider for dependency injection
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Self, RepoError>` - A `Repo` instance or an error
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - The path cannot be canonicalized
+    /// - The path does not contain a valid Git repository
+    /// - The repository cannot be opened due to permission issues
+    /// - The repository is corrupted or invalid
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sublime_git_tools::{Repo, SystemEnvProvider};
+    /// use std::sync::Arc;
+    ///
+    /// let repo = Repo::open_with_env("./my-project", Arc::new(SystemEnvProvider))
+    ///     .expect("Failed to open repository");
+    /// let branch = repo.get_current_branch().expect("Failed to get current branch");
+    /// println!("Current branch: {}", branch);
+    /// ```
+    #[allow(clippy::arc_with_non_send_sync)]
+    pub fn open_with_env(
+        path: &str,
+        env: Arc<dyn crate::env::EnvProvider>,
+    ) -> Result<Self, RepoError> {
         let local_path = canonicalize_path(path)?;
         let repo = Repository::open(path).map_err(RepoError::OpenRepoFailure)?;
 
-        Ok(Self { repo, local_path: PathBuf::from(local_path) })
+        Ok(Self { repo, local_path: PathBuf::from(local_path), env })
     }
 
     /// Clones a Git repository from a URL to a local path
@@ -417,10 +498,55 @@ impl Repo {
     ///     .expect("Failed to clone repository");
     /// ```
     pub fn clone(url: &str, path: &str) -> Result<Self, RepoError> {
+        Self::clone_with_env(url, path, Arc::new(crate::env::SystemEnvProvider))
+    }
+
+    /// Clones a Git repository from a URL to a local path with custom environment provider
+    ///
+    /// This method is primarily useful for testing scenarios where you need to control
+    /// environment variables without modifying the global process state.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL of the repository to clone
+    /// * `path` - The local path where the repository should be cloned
+    /// * `env` - Environment variable provider for dependency injection
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Self, RepoError>` - A `Repo` instance or an error
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - The path cannot be canonicalized
+    /// - The URL is invalid or unreachable
+    /// - Network connectivity issues prevent cloning
+    /// - Authentication is required but not provided or fails
+    /// - The destination path already exists or cannot be created
+    /// - Insufficient disk space or permissions
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sublime_git_tools::{Repo, SystemEnvProvider};
+    /// use std::sync::Arc;
+    ///
+    /// let repo = Repo::clone_with_env(
+    ///     "https://github.com/example/repo.git",
+    ///     "./cloned-repo",
+    ///     Arc::new(SystemEnvProvider)
+    /// ).expect("Failed to clone repository");
+    /// ```
+    pub fn clone_with_env(
+        url: &str,
+        path: &str,
+        env: Arc<dyn crate::env::EnvProvider>,
+    ) -> Result<Self, RepoError> {
         let local_path = canonicalize_path(path)?;
         let repo = Repository::clone(url, path).map_err(RepoError::CloneRepoFailure)?;
 
-        Ok(Self { repo, local_path: PathBuf::from(local_path) })
+        Ok(Self { repo, local_path: PathBuf::from(local_path), env })
     }
 
     /// Clones a Git repository from a URL to a local path with additional options.
@@ -492,6 +618,54 @@ impl Repo {
         path: &str,
         depth: Option<i32>,
     ) -> Result<Self, RepoError> {
+        Self::clone_with_options_and_env(url, path, depth, Arc::new(crate::env::SystemEnvProvider))
+    }
+
+    /// Clones a Git repository from a URL to a local path with additional options and custom environment provider
+    ///
+    /// This method provides advanced cloning capabilities including shallow clones
+    /// (limited history depth) and custom environment variable providers for testing.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL of the repository to clone
+    /// * `path` - The local path where the repository should be cloned
+    /// * `depth` - Optional depth for shallow clone (e.g., Some(1) for single commit)
+    /// * `env` - Environment variable provider for dependency injection
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Self, RepoError>` - A new `Repo` instance or an error
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if:
+    /// - Path canonicalization fails (`CanonicalPathFailure`)
+    /// - Clone operation fails (`CloneRepoFailure`)
+    /// - Network connection fails
+    /// - Authentication fails
+    /// - Insufficient disk space
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_git_tools::{Repo, SystemEnvProvider};
+    /// use std::sync::Arc;
+    ///
+    /// // Shallow clone with depth 1 (only latest commit)
+    /// let repo = Repo::clone_with_options_and_env(
+    ///     "https://github.com/example/large-repo.git",
+    ///     "./shallow-clone",
+    ///     Some(1),
+    ///     Arc::new(SystemEnvProvider)
+    /// )?;
+    /// ```
+    pub fn clone_with_options_and_env(
+        url: &str,
+        path: &str,
+        depth: Option<i32>,
+        env: Arc<dyn crate::env::EnvProvider>,
+    ) -> Result<Self, RepoError> {
         let local_path = canonicalize_path(path)?;
 
         // Build fetch options with depth if specified
@@ -507,7 +681,7 @@ impl Repo {
         // Perform the clone
         let repo = builder.clone(url, Path::new(path)).map_err(RepoError::CloneRepoFailure)?;
 
-        Ok(Self { repo, local_path: PathBuf::from(local_path) })
+        Ok(Self { repo, local_path: PathBuf::from(local_path), env })
     }
 
     /// Clones a Git repository with progress tracking.
@@ -544,7 +718,60 @@ impl Repo {
         url: &str,
         path: &str,
         depth: Option<i32>,
+        progress_cb: F,
+    ) -> Result<Self, RepoError>
+    where
+        F: FnMut(usize, usize) + 'static,
+    {
+        Self::clone_with_progress_and_env(
+            url,
+            path,
+            depth,
+            progress_cb,
+            Arc::new(crate::env::SystemEnvProvider),
+        )
+    }
+
+    /// Clones a Git repository with progress tracking and custom environment provider.
+    ///
+    /// This method provides real-time progress updates during the clone operation,
+    /// reporting the number of objects received and indexed, while allowing custom
+    /// environment variable providers for testing scenarios.
+    ///
+    /// # Arguments
+    ///
+    /// * `url` - The URL of the repository to clone
+    /// * `path` - The local path where the repository should be cloned
+    /// * `depth` - Optional depth for shallow clone
+    /// * `progress_cb` - Callback function receiving (current, total) objects
+    /// * `env` - Environment variable provider for dependency injection
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Self, RepoError>` - A new `Repo` instance or an error
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_git_tools::{Repo, SystemEnvProvider};
+    /// use std::sync::Arc;
+    ///
+    /// let repo = Repo::clone_with_progress_and_env(
+    ///     "https://github.com/example/repo.git",
+    ///     "./cloned-repo",
+    ///     None,
+    ///     |current, total| {
+    ///         println!("Progress: {}/{}", current, total);
+    ///     },
+    ///     Arc::new(SystemEnvProvider)
+    /// )?;
+    /// ```
+    pub fn clone_with_progress_and_env<F>(
+        url: &str,
+        path: &str,
+        depth: Option<i32>,
         mut progress_cb: F,
+        env: Arc<dyn crate::env::EnvProvider>,
     ) -> Result<Self, RepoError>
     where
         F: FnMut(usize, usize) + 'static,
@@ -573,7 +800,7 @@ impl Repo {
         // Canonicalize the path AFTER cloning (when the directory exists)
         let local_path = canonicalize_path(path)?;
 
-        Ok(Self { repo, local_path: PathBuf::from(local_path) })
+        Ok(Self { repo, local_path: PathBuf::from(local_path), env })
     }
 
     /// Gets the local path of the repository
@@ -1168,50 +1395,50 @@ impl Repo {
     fn resolve_branch_in_detached_head(&self) -> Result<String, RepoError> {
         // Strategy 1: Check CI environment variables
         // GitHub Actions
-        if let Ok(branch) = std::env::var("GITHUB_HEAD_REF")
+        if let Ok(branch) = self.env.var("GITHUB_HEAD_REF")
             && !branch.is_empty()
         {
             return Ok(branch);
         }
-        if let Ok(branch) = std::env::var("GITHUB_REF_NAME")
+        if let Ok(branch) = self.env.var("GITHUB_REF_NAME")
             && !branch.is_empty()
         {
             return Ok(branch);
         }
 
         // GitLab CI
-        if let Ok(branch) = std::env::var("CI_COMMIT_REF_NAME")
+        if let Ok(branch) = self.env.var("CI_COMMIT_REF_NAME")
             && !branch.is_empty()
         {
             return Ok(branch);
         }
 
         // CircleCI
-        if let Ok(branch) = std::env::var("CIRCLE_BRANCH")
+        if let Ok(branch) = self.env.var("CIRCLE_BRANCH")
             && !branch.is_empty()
         {
             return Ok(branch);
         }
 
         // Travis CI
-        if let Ok(branch) = std::env::var("TRAVIS_PULL_REQUEST_BRANCH")
+        if let Ok(branch) = self.env.var("TRAVIS_PULL_REQUEST_BRANCH")
             && !branch.is_empty()
         {
             return Ok(branch);
         }
-        if let Ok(branch) = std::env::var("TRAVIS_BRANCH")
+        if let Ok(branch) = self.env.var("TRAVIS_BRANCH")
             && !branch.is_empty()
         {
             return Ok(branch);
         }
 
         // Jenkins
-        if let Ok(branch) = std::env::var("CHANGE_BRANCH")
+        if let Ok(branch) = self.env.var("CHANGE_BRANCH")
             && !branch.is_empty()
         {
             return Ok(branch);
         }
-        if let Ok(branch) = std::env::var("BRANCH_NAME")
+        if let Ok(branch) = self.env.var("BRANCH_NAME")
             && !branch.is_empty()
         {
             return Ok(branch);
@@ -3599,8 +3826,11 @@ mod tests {
         let _ = std::fs::remove_dir_all(&temp_dir); // Clean up if exists
         std::fs::create_dir_all(&temp_dir).unwrap();
 
-        let repo =
-            Repo { repo: git2::Repository::init_bare(&temp_dir).unwrap(), local_path: temp_dir };
+        let repo = Repo {
+            repo: git2::Repository::init_bare(&temp_dir).unwrap(),
+            local_path: temp_dir,
+            env: Arc::new(crate::env::SystemEnvProvider),
+        };
 
         // Test standard semantic versions
         assert_eq!(repo.parse_semantic_version("1.2.3"), Some((1, 2, 3, None)));
@@ -3633,8 +3863,11 @@ mod tests {
         let _ = std::fs::remove_dir_all(&temp_dir); // Clean up if exists
         std::fs::create_dir_all(&temp_dir).unwrap();
 
-        let repo =
-            Repo { repo: git2::Repository::init_bare(&temp_dir).unwrap(), local_path: temp_dir };
+        let repo = Repo {
+            repo: git2::Repository::init_bare(&temp_dir).unwrap(),
+            local_path: temp_dir,
+            env: Arc::new(crate::env::SystemEnvProvider),
+        };
 
         // Test semantic version comparison
         assert_eq!(repo.compare_version_tags("v1.2.3", "v2.0.0"), Ordering::Less);

--- a/crates/git/src/tests.rs
+++ b/crates/git/src/tests.rs
@@ -11,6 +11,7 @@ mod tests {
         fs::{File, canonicalize, create_dir, remove_dir_all},
         io::Write,
         path::PathBuf,
+        sync::Arc,
     };
 
     #[cfg(not(windows))]
@@ -953,20 +954,14 @@ mod tests {
         // This test simulates GitHub Actions environment where the repository
         // is in detached HEAD state but GITHUB_REF_NAME is set
 
-        // Save original env value if it exists
-        let original_value = std::env::var("GITHUB_REF_NAME").ok();
-
-        // Set the environment variable to simulate GitHub Actions
-        // Safety: This is safe in a test environment as we're controlling the execution
-        // and restoring the original value at the end
-        unsafe {
-            std::env::set_var("GITHUB_REF_NAME", "feature/bff");
-        }
-
         let workspace = TestWorkspace::new().unwrap();
         let workspace_path = workspace.path();
 
-        let repo = Repo::create(workspace_path.display().to_string().as_str())?;
+        // Create a mock environment provider with GITHUB_REF_NAME set
+        let mock_env =
+            Arc::new(crate::env::MockEnvProvider::new().with_var("GITHUB_REF_NAME", "feature/bff"));
+
+        let repo = Repo::create_with_env(workspace_path.display().to_string().as_str(), mock_env)?;
         repo.config("Sublime Git Bot", "git-boot@websublime.com")?;
 
         // Create a commit to have a valid HEAD
@@ -994,15 +989,6 @@ mod tests {
         // we should get "feature/bff" from the environment variable
         let detached_branch = repo.get_current_branch()?;
         assert_eq!(detached_branch, String::from("feature/bff"));
-
-        // Cleanup: restore original environment variable
-        // Safety: This is safe in a test environment as we're restoring the state
-        unsafe {
-            match original_value {
-                Some(val) => std::env::set_var("GITHUB_REF_NAME", val),
-                None => std::env::remove_var("GITHUB_REF_NAME"),
-            }
-        }
 
         Ok(())
     }

--- a/crates/git/src/types.rs
+++ b/crates/git/src/types.rs
@@ -1,5 +1,6 @@
 use git2::{Error as Git2Error, Repository};
 use std::path::PathBuf;
+use std::sync::Arc;
 use thiserror::Error;
 
 /// Represents a Git repository with high-level operation methods
@@ -22,9 +23,11 @@ use thiserror::Error;
 /// repo.add_all().expect("Failed to stage changes");
 /// let commit_id = repo.commit("feat: add new feature").expect("Failed to commit");
 /// ```
+#[allow(clippy::struct_field_names)]
 pub struct Repo {
     pub(crate) repo: Repository,
     pub(crate) local_path: PathBuf,
+    pub(crate) env: Arc<dyn crate::env::EnvProvider>,
 }
 
 /// Represents the status of a file in Git


### PR DESCRIPTION


- Enhanced get_current_branch() to detect detached HEAD state
- Added resolution strategies for CI environment variables (GitHub Actions, GitLab, CircleCI, Travis, Jenkins)
- Fallback to local and remote branch detection when env vars unavailable
- Resolves snapshot version generation using "head" instead of actual branch name
- Added test coverage for GitHub Actions environment simulation

Closes WOR-TSK-148