### PR TITLE
chore(WOR-TSK-151): remove unnecessary clippy annotation from output_init_result

### DIFF
--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -959,7 +959,6 @@ updatedAt: "2024-01-01T00:00:00Z"
 /// Returns an error if:
 /// - JSON serialization fails
 /// - Writing to output stream fails
-#[allow(clippy::print_stdout)]
 fn output_init_result(
     config_path: &Path,
     config: &InitConfig,


### PR DESCRIPTION


Story 2.2 was already implemented in Story 2.1, but output_init_result had an unnecessary #[allow(clippy::print_stdout)] annotation since it no longer uses println!() but instead uses Output methods.

- Remove #[allow(clippy::print_stdout)] from output_init_result function
- Function now uses output.success(), output.info(), output.json()
- All clippy checks pass
- All 40 init tests pass