### PR TITLE
feat(WOR-TSK-153): implement Story 3.1 - refactor execute_show to Pattern B

### DIFF
--- a/crates/cli/src/cli/dispatch.rs
+++ b/crates/cli/src/cli/dispatch.rs
@@ -108,7 +108,14 @@ pub async fn dispatch_command(cli: &Cli) -> Result<()> {
 
         Commands::Config(config_cmd) => match config_cmd {
             ConfigCommands::Show(args) => {
-                config::execute_show(args, root, config_path.map(PathBuf::as_path), format).await?;
+                let output = Output::new(format, std::io::stdout(), cli.is_color_disabled());
+                config::execute_show(
+                    args,
+                    &output,
+                    root,
+                    config_path.as_ref().map(|p| p.as_path()),
+                )
+                .await?;
             }
             ConfigCommands::Validate(args) => {
                 config::execute_validate(args, root, config_path.map(PathBuf::as_path), format)

--- a/crates/cli/src/commands/config.rs
+++ b/crates/cli/src/commands/config.rs
@@ -45,7 +45,7 @@
 
 use crate::cli::commands::{ConfigShowArgs, ConfigValidateArgs};
 use crate::error::{CliError, Result};
-use crate::output::{JsonResponse, OutputFormat};
+use crate::output::{JsonResponse, Output, OutputFormat};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -62,9 +62,9 @@ use tracing::{debug, info, warn};
 /// # Arguments
 ///
 /// * `_args` - Command arguments (currently unused but reserved for future options)
+/// * `output` - Output handler for formatting command results
 /// * `root` - Workspace root directory
 /// * `config_path` - Optional path to config file (from global `--config` option)
-/// * `format` - Output format for the command result
 ///
 /// # Returns
 ///
@@ -82,20 +82,21 @@ use tracing::{debug, info, warn};
 /// ```rust,ignore
 /// use sublime_cli_tools::commands::config::execute_show;
 /// use sublime_cli_tools::cli::commands::ConfigShowArgs;
-/// use sublime_cli_tools::output::OutputFormat;
+/// use sublime_cli_tools::output::{Output, OutputFormat};
 /// use std::path::Path;
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let args = ConfigShowArgs {};
-/// execute_show(&args, Path::new("."), None, OutputFormat::Human).await?;
+/// let output = Output::new(OutputFormat::Human, std::io::stdout(), false);
+/// execute_show(&args, &output, Path::new("."), None).await?;
 /// # Ok(())
 /// # }
 /// ```
 pub async fn execute_show(
     _args: &ConfigShowArgs,
+    output: &Output,
     root: &Path,
     config_path: Option<&Path>,
-    format: OutputFormat,
 ) -> Result<()> {
     debug!("Loading configuration from: {}", root.display());
 
@@ -152,9 +153,9 @@ pub async fn execute_show(
     };
 
     // Output based on format
-    match format {
+    match output.format() {
         OutputFormat::Human => output_human_format(&config, is_default),
-        OutputFormat::Json | OutputFormat::JsonCompact => output_json_format(&config, format)?,
+        OutputFormat::Json | OutputFormat::JsonCompact => output_json_format(&config, output)?,
         OutputFormat::Quiet => output_quiet_format(&config),
     }
 
@@ -739,27 +740,18 @@ fn output_human_format(config: &PackageToolsConfig, is_default: bool) {
 /// Output configuration in JSON format.
 ///
 /// Serializes the configuration as a JsonResponse structure for machine-readable
-/// output. Uses pretty printing for Json format and compact for JsonCompact.
+/// output. Uses the Output struct to handle formatting (pretty vs compact).
 ///
 /// # Errors
 ///
 /// Returns an error if JSON serialization fails.
-fn output_json_format(config: &PackageToolsConfig, format: OutputFormat) -> Result<()> {
+fn output_json_format(config: &PackageToolsConfig, output: &Output) -> Result<()> {
     // Convert to serializable structure
     let config_data = ConfigShowData::from(config);
     let response = JsonResponse::success(config_data);
 
-    // Serialize based on format
-    let json_str = if format == OutputFormat::JsonCompact {
-        serde_json::to_string(&response)
-            .map_err(|e| CliError::execution(format!("Failed to serialize JSON: {e}")))?
-    } else {
-        serde_json::to_string_pretty(&response)
-            .map_err(|e| CliError::execution(format!("Failed to serialize JSON: {e}")))?
-    };
-
-    println!("{json_str}");
-    Ok(())
+    // Use output.json() to handle serialization and formatting
+    output.json(&response)
 }
 
 /// Output configuration in quiet format.

--- a/crates/cli/src/commands/tests.rs
+++ b/crates/cli/src/commands/tests.rs
@@ -1266,7 +1266,7 @@ mod changes_tests {
 mod config_tests {
     use crate::cli::commands::{ConfigShowArgs, ConfigValidateArgs};
     use crate::commands::config::{execute_show, execute_validate};
-    use crate::output::OutputFormat;
+    use crate::output::{Output, OutputFormat};
     use std::fs;
     use tempfile::TempDir;
 
@@ -1305,7 +1305,8 @@ mod config_tests {
         create_config_file(&temp_dir, "toml");
 
         let args = ConfigShowArgs {};
-        let result = execute_show(&args, temp_dir.path(), None, OutputFormat::Quiet).await;
+        let output = Output::new(OutputFormat::Quiet, std::io::stdout(), false);
+        let result = execute_show(&args, &output, temp_dir.path(), None).await;
 
         assert!(result.is_ok(), "Config show failed: {result:?}");
     }
@@ -1316,7 +1317,8 @@ mod config_tests {
         create_config_file(&temp_dir, "json");
 
         let args = ConfigShowArgs {};
-        let result = execute_show(&args, temp_dir.path(), None, OutputFormat::Quiet).await;
+        let output = Output::new(OutputFormat::Quiet, std::io::stdout(), false);
+        let result = execute_show(&args, &output, temp_dir.path(), None).await;
 
         assert!(result.is_ok(), "Config show with JSON config failed: {result:?}");
     }
@@ -1327,7 +1329,8 @@ mod config_tests {
         create_config_file(&temp_dir, "yaml");
 
         let args = ConfigShowArgs {};
-        let result = execute_show(&args, temp_dir.path(), None, OutputFormat::Quiet).await;
+        let output = Output::new(OutputFormat::Quiet, std::io::stdout(), false);
+        let result = execute_show(&args, &output, temp_dir.path(), None).await;
 
         assert!(result.is_ok(), "Config show with YAML config failed: {result:?}");
     }
@@ -1338,7 +1341,8 @@ mod config_tests {
         // Don't create config file
 
         let args = ConfigShowArgs {};
-        let result = execute_show(&args, temp_dir.path(), None, OutputFormat::Quiet).await;
+        let output = Output::new(OutputFormat::Quiet, std::io::stdout(), false);
+        let result = execute_show(&args, &output, temp_dir.path(), None).await;
 
         // Should succeed with default config
         assert!(result.is_ok(), "Config show without config should use defaults: {result:?}");
@@ -1350,7 +1354,8 @@ mod config_tests {
         create_config_file(&temp_dir, "toml");
 
         let args = ConfigShowArgs {};
-        let result = execute_show(&args, temp_dir.path(), None, OutputFormat::Human).await;
+        let output = Output::new(OutputFormat::Human, std::io::stdout(), false);
+        let result = execute_show(&args, &output, temp_dir.path(), None).await;
 
         assert!(result.is_ok(), "Config show in human format failed: {result:?}");
     }
@@ -1361,7 +1366,8 @@ mod config_tests {
         create_config_file(&temp_dir, "toml");
 
         let args = ConfigShowArgs {};
-        let result = execute_show(&args, temp_dir.path(), None, OutputFormat::Json).await;
+        let output = Output::new(OutputFormat::Json, std::io::stdout(), false);
+        let result = execute_show(&args, &output, temp_dir.path(), None).await;
 
         assert!(result.is_ok(), "Config show in JSON format failed: {result:?}");
     }
@@ -1372,7 +1378,8 @@ mod config_tests {
         create_config_file(&temp_dir, "toml");
 
         let args = ConfigShowArgs {};
-        let result = execute_show(&args, temp_dir.path(), None, OutputFormat::JsonCompact).await;
+        let output = Output::new(OutputFormat::JsonCompact, std::io::stdout(), false);
+        let result = execute_show(&args, &output, temp_dir.path(), None).await;
 
         assert!(result.is_ok(), "Config show in JSON compact format failed: {result:?}");
     }
@@ -1383,7 +1390,8 @@ mod config_tests {
         create_config_file(&temp_dir, "toml");
 
         let args = ConfigShowArgs {};
-        let result = execute_show(&args, temp_dir.path(), None, OutputFormat::Quiet).await;
+        let output = Output::new(OutputFormat::Quiet, std::io::stdout(), false);
+        let result = execute_show(&args, &output, temp_dir.path(), None).await;
 
         assert!(result.is_ok(), "Config show in quiet format failed: {result:?}");
     }
@@ -2004,8 +2012,9 @@ version_consistency = true
 
         let args = ConfigShowArgs {};
         let custom_path = temp_dir.path().join("custom.toml");
+        let output = Output::new(OutputFormat::Quiet, std::io::stdout(), false);
         let result =
-            execute_show(&args, temp_dir.path(), Some(&custom_path), OutputFormat::Quiet).await;
+            execute_show(&args, &output, temp_dir.path(), Some(custom_path.as_path())).await;
 
         assert!(result.is_ok(), "Config show should work with custom config path: {result:?}");
     }
@@ -2016,8 +2025,9 @@ version_consistency = true
 
         let args = ConfigShowArgs {};
         let custom_path = temp_dir.path().join("nonexistent.toml");
+        let output = Output::new(OutputFormat::Quiet, std::io::stdout(), false);
         let result =
-            execute_show(&args, temp_dir.path(), Some(&custom_path), OutputFormat::Quiet).await;
+            execute_show(&args, &output, temp_dir.path(), Some(custom_path.as_path())).await;
 
         assert!(result.is_err(), "Config show should fail with nonexistent custom config");
         let err = result.unwrap_err();

--- a/crates/cli/tests/e2e_config.rs
+++ b/crates/cli/tests/e2e_config.rs
@@ -23,7 +23,7 @@ use common::fixtures::WorkspaceFixture;
 use serde_json::json;
 use sublime_cli_tools::cli::commands::{ConfigShowArgs, ConfigValidateArgs};
 use sublime_cli_tools::commands::config::{execute_show, execute_validate};
-use sublime_cli_tools::output::OutputFormat;
+use sublime_cli_tools::output::{Output, OutputFormat};
 
 // ============================================================================
 // Helper Functions
@@ -121,7 +121,8 @@ async fn test_config_show_displays_current() {
     let args = ConfigShowArgs {};
 
     // ACT: Execute config show command
-    let result = execute_show(&args, workspace.root(), None, OutputFormat::Human).await;
+    let output = Output::new(OutputFormat::Human, std::io::stdout(), false);
+    let result = execute_show(&args, &output, workspace.root(), None).await;
 
     // ASSERT: Command should succeed
     assert!(result.is_ok(), "Config show should succeed: {:?}", result.err());
@@ -143,7 +144,8 @@ async fn test_config_show_json_output() {
     let args = ConfigShowArgs {};
 
     // ACT: Execute config show command with JSON format
-    let result = execute_show(&args, workspace.root(), None, OutputFormat::Json).await;
+    let output = Output::new(OutputFormat::Json, std::io::stdout(), false);
+    let result = execute_show(&args, &output, workspace.root(), None).await;
 
     // ASSERT: Command should succeed and output should be valid JSON
     assert!(result.is_ok(), "Config show with JSON format should succeed: {:?}", result.err());
@@ -164,7 +166,8 @@ async fn test_config_show_missing_config_uses_defaults() {
     let args = ConfigShowArgs {};
 
     // ACT: Execute config show command (no config file exists)
-    let result = execute_show(&args, workspace.root(), None, OutputFormat::Human).await;
+    let output = Output::new(OutputFormat::Human, std::io::stdout(), false);
+    let result = execute_show(&args, &output, workspace.root(), None).await;
 
     // ASSERT: Command should succeed and show defaults
     assert!(result.is_ok(), "Config show should succeed with defaults: {:?}", result.err());
@@ -187,8 +190,9 @@ async fn test_config_show_with_custom_config_path() {
     let args = ConfigShowArgs {};
 
     // ACT: Execute config show with custom path
+    let output = Output::new(OutputFormat::Human, std::io::stdout(), false);
     let result =
-        execute_show(&args, workspace.root(), Some(&custom_config_path), OutputFormat::Human).await;
+        execute_show(&args, &output, workspace.root(), Some(custom_config_path.as_path())).await;
 
     // ASSERT: Command should succeed
     assert!(result.is_ok(), "Config show with custom path should succeed: {:?}", result.err());
@@ -207,8 +211,9 @@ async fn test_config_show_custom_path_not_found() {
     let args = ConfigShowArgs {};
 
     // ACT: Execute config show with non-existent path
+    let output = Output::new(OutputFormat::Human, std::io::stdout(), false);
     let result =
-        execute_show(&args, workspace.root(), Some(&non_existent_path), OutputFormat::Human).await;
+        execute_show(&args, &output, workspace.root(), Some(non_existent_path.as_path())).await;
 
     // ASSERT: Command should fail with appropriate error
     assert!(result.is_err(), "Config show should fail with non-existent custom path");
@@ -230,7 +235,8 @@ async fn test_config_show_quiet_output() {
     let args = ConfigShowArgs {};
 
     // ACT: Execute config show with quiet format
-    let result = execute_show(&args, workspace.root(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::stdout(), false);
+    let result = execute_show(&args, &output, workspace.root(), None).await;
 
     // ASSERT: Command should succeed
     assert!(result.is_ok(), "Config show with quiet format should succeed: {:?}", result.err());
@@ -412,7 +418,8 @@ async fn test_config_show_monorepo_independent() {
     let args = ConfigShowArgs {};
 
     // ACT: Execute config show command
-    let result = execute_show(&args, workspace.root(), None, OutputFormat::Human).await;
+    let output = Output::new(OutputFormat::Human, std::io::stdout(), false);
+    let result = execute_show(&args, &output, workspace.root(), None).await;
 
     // ASSERT: Command should succeed
     assert!(result.is_ok(), "Config show in monorepo should succeed: {:?}", result.err());
@@ -770,7 +777,8 @@ min_severity = "info"
     let args = ConfigShowArgs {};
 
     // ACT: Execute config show command
-    let result = execute_show(&args, workspace.root(), None, OutputFormat::Human).await;
+    let output = Output::new(OutputFormat::Human, std::io::stdout(), false);
+    let result = execute_show(&args, &output, workspace.root(), None).await;
 
     // ASSERT: Command should succeed with TOML format
     assert!(result.is_ok(), "Config show should succeed with TOML format: {:?}", result.err());
@@ -840,7 +848,8 @@ audit:
     let args = ConfigShowArgs {};
 
     // ACT: Execute config show command
-    let result = execute_show(&args, workspace.root(), None, OutputFormat::Human).await;
+    let output = Output::new(OutputFormat::Human, std::io::stdout(), false);
+    let result = execute_show(&args, &output, workspace.root(), None).await;
 
     // ASSERT: Command should succeed with YAML format
     assert!(result.is_ok(), "Config show should succeed with YAML format: {:?}", result.err());


### PR DESCRIPTION


Migrate execute_show function from Pattern A (legacy) to Pattern B (modern) signature to achieve consistency across the CLI codebase.

Changes:
- Update execute_show signature to use &Output instead of OutputFormat
- Refactor output_json_format to use output.json() method
- Update dispatch.rs to create Output before calling execute_show
- Update all test files (e2e_config.rs and commands/tests.rs)

Benefits:
- Consistency with 23 other functions already using Pattern B
- Enables output capture for tests and Node.js bindings
- Removes ~15 lines of duplicate JSON serialization code
- Improves testability and maintainability

Acceptance Criteria Met:
- Function signature matches Pattern B
- Compiles without errors (cargo build + clippy)
- All tests passing (22 e2e tests + unit tests)
- Documentation updated

Story: Epic 3 - Config Commands Refactoring, Story 3.1