### PR TITLE
refactor(WOR-TSK-157): implement Story 4.1 - refactor execute_clone signature to Pattern B

### DIFF
--- a/crates/cli/src/cli/dispatch.rs
+++ b/crates/cli/src/cli/dispatch.rs
@@ -282,11 +282,12 @@ pub async fn dispatch_command(cli: &Cli) -> Result<()> {
         }
 
         Commands::Clone(args) => {
+            let output = Output::new(format, std::io::stdout(), cli.is_color_disabled());
             crate::commands::clone::execute_clone(
                 args,
+                &output,
                 root,
-                config_path.map(PathBuf::as_path),
-                format,
+                config_path.as_ref().map(|p| p.as_path()),
             )
             .await?;
         }

--- a/crates/cli/src/commands/clone.rs
+++ b/crates/cli/src/commands/clone.rs
@@ -768,7 +768,9 @@ fn map_git_error(error: &sublime_git_tools::RepoError, url: &str) -> CliError {
 /// # Arguments
 ///
 /// * `args` - Clone command arguments containing URL, destination, and options
-/// * `format` - Output format for progress and messages
+/// * `output` - Output handler for consistent formatting across all commands
+/// * `root` - Root directory for the workspace
+/// * `config_path` - Optional path to configuration file
 ///
 /// # Returns
 ///
@@ -785,6 +787,9 @@ fn map_git_error(error: &sublime_git_tools::RepoError, url: &str) -> CliError {
 /// # Examples
 ///
 /// ```rust,ignore
+/// use sublime_cli_tools::output::{Output, OutputFormat};
+/// use std::io;
+///
 /// let args = CloneArgs {
 ///     url: "https://github.com/org/repo.git".to_string(),
 ///     destination: None,
@@ -793,13 +798,14 @@ fn map_git_error(error: &sublime_git_tools::RepoError, url: &str) -> CliError {
 ///     // ... other fields
 /// };
 ///
-/// execute_clone(&args, Path::new("."), None, OutputFormat::Human).await?;
+/// let output = Output::new(OutputFormat::Human, io::stdout(), false);
+/// execute_clone(&args, &output, Path::new("."), None).await?;
 /// ```
 pub async fn execute_clone(
     args: &CloneArgs,
+    output: &crate::output::Output,
     root: &Path,
     config_path: Option<&Path>,
-    format: OutputFormat,
 ) -> Result<()> {
     // Step 1: Determine destination directory
     let destination = determine_destination(&args.url, args.destination.as_ref())?;
@@ -828,7 +834,7 @@ pub async fn execute_clone(
 
     // Step 5: Clone repository with progress
     debug!("Cloning repository from {} to {}", args.url, final_destination.display());
-    let _repo = clone_with_progress(&args.url, &final_destination, args.depth, format)?;
+    let _repo = clone_with_progress(&args.url, &final_destination, args.depth, output.format())?;
     info!("Repository cloned successfully to {}", final_destination.display());
 
     // Step 6: Detect workspace configuration (Story 11.3)
@@ -846,7 +852,7 @@ pub async fn execute_clone(
             false
         } else {
             debug!("Validating workspace configuration");
-            output_validation_starting(format);
+            output_validation_starting(output.format());
             let validation = validate_workspace(&final_destination).await?;
 
             if !validation.is_valid {
@@ -857,16 +863,16 @@ pub async fn execute_clone(
             }
 
             info!("Workspace configuration validated successfully");
-            output_validation_success(&validation, format);
+            output_validation_success(&validation, output.format());
             true
         };
 
-        output_clone_complete(&final_destination, validated, format)?;
+        output_clone_complete(&final_destination, validated, output.format())?;
     } else {
         info!("No workspace configuration found, initializing workspace");
 
         // No configuration - run init automatically
-        output_init_starting(format);
+        output_init_starting(output.format());
 
         // Convert CloneArgs to InitArgs with configuration merge
         // Note: No workspace config exists yet, so we only use CLI args + defaults
@@ -875,14 +881,10 @@ pub async fn execute_clone(
         // Execute init command
         debug!("Executing init to create workspace configuration");
 
-        // TODO: will be implemented in Story 4.2 - Clone command will be refactored to use Output struct
-        // For now, create Output instance to match execute_init's Pattern B signature
-        #[allow(clippy::todo)]
-        let init_output = crate::output::Output::new(format, std::io::stdout(), false);
-        crate::commands::init::execute_init(&init_args, &init_output, &final_destination, None)
-            .await?;
+        // Use the output parameter directly (execute_init already uses Pattern B)
+        crate::commands::init::execute_init(&init_args, output, &final_destination, None).await?;
 
-        output_clone_complete_with_init(&final_destination, format)?;
+        output_clone_complete_with_init(&final_destination, output.format())?;
     }
 
     Ok(())

--- a/crates/cli/tests/e2e_clone.rs
+++ b/crates/cli/tests/e2e_clone.rs
@@ -22,7 +22,7 @@ use common::helpers::read_json_file;
 use std::path::{Path, PathBuf};
 use sublime_cli_tools::cli::commands::CloneArgs;
 use sublime_cli_tools::commands::clone::execute_clone;
-use sublime_cli_tools::output::OutputFormat;
+use sublime_cli_tools::output::{Output, OutputFormat};
 use tempfile::TempDir;
 
 // ============================================================================
@@ -83,7 +83,8 @@ async fn test_clone_without_config_runs_init() {
     };
 
     // Execute clone
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_ok(), "Clone should succeed: {:?}", result.err());
 
     // Verify repository was cloned and workspace was initialized
@@ -124,7 +125,8 @@ async fn test_clone_with_valid_config_validates() {
     };
 
     // Execute clone
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_ok(), "Clone should succeed: {:?}", result.err());
 
     // Verify repository was cloned and workspace structure is intact
@@ -165,7 +167,8 @@ async fn test_clone_monorepo_with_valid_config() {
     };
 
     // Execute clone
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_ok(), "Clone should succeed: {:?}", result.err());
 
     // Verify monorepo structure
@@ -218,7 +221,8 @@ async fn test_clone_force_removes_existing() {
     };
 
     // Execute clone
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_ok(), "Clone with force should succeed: {:?}", result.err());
 
     // Verify old content is gone
@@ -262,7 +266,8 @@ async fn test_clone_skip_validation() {
     };
 
     // Execute clone - should succeed even though config is invalid
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_ok(), "Clone with skip validation should succeed: {:?}", result.err());
 
     // Verify repository was cloned
@@ -297,7 +302,8 @@ async fn test_clone_with_config_overrides() {
     };
 
     // Execute clone
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_ok(), "Clone with overrides should succeed: {:?}", result.err());
 
     // Verify custom configuration was applied
@@ -333,7 +339,8 @@ async fn test_clone_non_interactive() {
     };
 
     // Execute clone - should succeed without prompts
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_ok(), "Non-interactive clone should succeed: {:?}", result.err());
 
     // Verify workspace was initialized with defaults
@@ -366,7 +373,8 @@ async fn test_clone_invalid_url_fails() {
     };
 
     // Execute clone - should fail
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_err(), "Clone with invalid URL should fail");
 }
 
@@ -407,7 +415,8 @@ async fn test_clone_destination_exists_fails_without_force() {
     };
 
     // Execute clone - should fail
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_err(), "Clone should fail when destination exists without force");
 }
 
@@ -445,7 +454,8 @@ async fn test_clone_invalid_config_fails_validation() {
     };
 
     // Execute clone - should fail validation
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_err(), "Clone should fail validation with invalid config");
 }
 
@@ -486,7 +496,8 @@ async fn test_clone_absolute_vs_relative_paths() {
         depth: None,
     };
 
-    let result = execute_clone(&args_absolute, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args_absolute, &output, clone_dest.path(), None).await;
     assert!(result.is_ok(), "Clone with absolute path should succeed");
     assert!(clone_path_absolute.exists(), "Absolute path destination should exist");
 
@@ -507,7 +518,8 @@ async fn test_clone_absolute_vs_relative_paths() {
         depth: None,
     };
 
-    let result = execute_clone(&args_relative, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args_relative, &output, clone_dest.path(), None).await;
     assert!(result.is_ok(), "Clone with relative path should succeed");
 
     // Relative path should be resolved relative to root
@@ -547,7 +559,8 @@ async fn test_clone_json_output_structure() {
     };
 
     // Execute clone with JSON output
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Json).await;
+    let output = Output::new(OutputFormat::Json, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_ok(), "Clone should succeed");
 
     // Verify repository was cloned
@@ -589,7 +602,8 @@ async fn test_clone_then_changeset_creation() {
     };
 
     // Execute clone
-    let result = execute_clone(&args, clone_dest.path(), None, OutputFormat::Quiet).await;
+    let output = Output::new(OutputFormat::Quiet, std::io::sink(), true);
+    let result = execute_clone(&args, &output, clone_dest.path(), None).await;
     assert!(result.is_ok(), "Clone should succeed");
 
     // Verify .changesets directory is ready for changesets


### PR DESCRIPTION


Migrate execute_clone from Pattern A (OutputFormat enum) to Pattern B (Output struct) for consistency across all CLI commands.

Changes:
- Update execute_clone signature to accept &Output instead of OutputFormat
- Update internal logic to use output.format() instead of format
- Remove temporary TODO workaround for execute_init integration
- Update dispatch.rs to create and pass Output struct
- Update all test calls in e2e_clone.rs to use new signature
- Update function documentation with Pattern B examples

This completes the signature migration for clone command. Output helper refactoring will be done in Story 4.2.

Verification:
- All 13 e2e tests passing
- All 61 unit tests passing
- Clippy clean with -D warnings
- Zero compilation errors

BREAKING CHANGE: Internal API only - execute_clone signature changed