### PR TITLE
feat(WOR-TSK-165): implement backup control parameter for upgrade apply command

### DIFF
--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -517,7 +517,7 @@ workspace upgrade apply [OPTIONS]
 - `--packages <LIST>` - Comma-separated list of packages to upgrade
 - `--auto-changeset` - Automatically create changeset for upgrades
 - `--changeset-bump <TYPE>` - Changeset bump type (`major`, `minor`, or `patch`; default: `patch`)
-- `--no-backup` - Skip backup creation
+- `--no-backup` - Skip backup creation (use with caution! recommended for CI/CD or when using Git for version control)
 - `--force` - Skip confirmations
 
 **Examples:**
@@ -533,6 +533,10 @@ workspace upgrade apply --patch-only --force
 
 # Apply upgrades for specific packages
 workspace upgrade apply --packages "@myorg/core"
+
+# Apply without backup (CI/CD scenario with Git version control)
+git add . && git commit -m "Pre-upgrade commit"
+workspace upgrade apply --no-backup --force
 ```
 
 #### `upgrade backups` - Manage Upgrade Backups

--- a/crates/cli/src/cli/commands.rs
+++ b/crates/cli/src/cli/commands.rs
@@ -696,7 +696,20 @@ pub struct UpgradeApplyArgs {
 
     /// Skip backup creation.
     ///
-    /// Does not create a backup before upgrading.
+    /// Does not create a backup before upgrading. Use with caution!
+    ///
+    /// Backups allow rollback via 'workspace upgrade backups restore'.
+    /// Without backups, you must rely on Git history for recovery.
+    ///
+    /// Recommended for:
+    /// - CI/CD pipelines with version control
+    /// - Testing environments
+    /// - When Git commits provide sufficient backup
+    ///
+    /// ⚠ Not recommended for:
+    /// - Production environments
+    /// - Uncommitted changes
+    /// - First-time users
     #[arg(long)]
     pub no_backup: bool,
 

--- a/crates/cli/src/commands/upgrade/apply.rs
+++ b/crates/cli/src/commands/upgrade/apply.rs
@@ -182,7 +182,23 @@ pub async fn execute_upgrade_apply(
         }
     }
 
-    // Step 8: Apply upgrades (or dry-run)
+    // Step 8: Determine backup setting
+    let backup_enabled = if args.no_backup {
+        Some(false) // Explicitly disable backups
+    } else {
+        None // Use config default
+    };
+
+    // Step 9: Show warning if backups disabled
+    if args.no_backup && !output.format().is_json() {
+        output.warning(
+            "⚠ Backups disabled. Changes cannot be rolled back via 'workspace upgrade backups restore'."
+        )?;
+        output.info("💡 Consider committing changes to Git before proceeding.")?;
+        output.blank_line()?;
+    }
+
+    // Step 10: Apply upgrades (or dry-run)
     // Note: Changeset creation is controlled by UpgradeManager's config.auto_changeset
     // For now, we'll note this limitation and implement changeset support in a future story
     if args.auto_changeset {
@@ -190,19 +206,19 @@ pub async fn execute_upgrade_apply(
         // TODO: will be implemented on story 6.2 completion - integrate with ChangesetManager
     }
 
-    info!("Applying upgrades (dry_run={})", args.dry_run);
+    info!("Applying upgrades (dry_run={}, backup_enabled={:?})", args.dry_run, backup_enabled);
 
     // Clone selection to use after apply_upgrades (which consumes it)
     let selection_for_result = selection.clone();
 
     let upgrade_result = upgrade_manager
-        .apply_upgrades(selection, args.dry_run)
+        .apply_upgrades(selection, args.dry_run, backup_enabled)
         .await
         .map_err(|e| CliError::execution(format!("Failed to apply upgrades: {e}")))?;
 
     debug!("Applied {} upgrades", upgrade_result.applied.len());
 
-    // Step 9: Convert results and output
+    // Step 11: Convert results and output
     let (applied, skipped, summary) = convert_upgrade_result(
         &upgrade_result,
         &available_upgrades.packages,
@@ -210,7 +226,7 @@ pub async fn execute_upgrade_apply(
         args.dry_run,
     );
 
-    output_results(output, applied, skipped, summary, args.dry_run)?;
+    output_results(output, applied, skipped, summary, args.dry_run, args.no_backup)?;
 
     info!("Upgrade apply completed successfully");
     Ok(())
@@ -556,6 +572,7 @@ fn output_no_upgrades(output: &Output) -> Result<()> {
 /// * `skipped` - Skipped upgrades
 /// * `summary` - Summary statistics
 /// * `is_dry_run` - Whether this was a dry-run operation
+/// * `backups_disabled` - Whether backups were explicitly disabled via --no-backup
 ///
 /// # Returns
 ///
@@ -570,13 +587,14 @@ fn output_results(
     skipped: Vec<SkippedUpgradeInfo>,
     summary: ApplySummary,
     is_dry_run: bool,
+    backups_disabled: bool,
 ) -> Result<()> {
     match output.format() {
         crate::output::OutputFormat::Json | crate::output::OutputFormat::JsonCompact => {
             output_json(output, applied, skipped, summary)
         }
         crate::output::OutputFormat::Human => {
-            output_human(output, &applied, &skipped, &summary, is_dry_run)
+            output_human(output, &applied, &skipped, &summary, is_dry_run, backups_disabled)
         }
         crate::output::OutputFormat::Quiet => output_quiet(output, &summary, is_dry_run),
     }
@@ -615,6 +633,7 @@ fn output_json(
 /// * `skipped` - Skipped upgrades
 /// * `summary` - Summary statistics
 /// * `is_dry_run` - Whether this was a dry-run
+/// * `backups_disabled` - Whether backups were explicitly disabled
 ///
 /// # Returns
 ///
@@ -625,6 +644,7 @@ fn output_human(
     skipped: &[SkippedUpgradeInfo],
     summary: &ApplySummary,
     is_dry_run: bool,
+    backups_disabled: bool,
 ) -> Result<()> {
     use console::style;
 
@@ -685,6 +705,11 @@ fn output_human(
         output.plain(
             &style("  Use `workspace upgrade backups restore <ID>` to rollback").dim().to_string(),
         )?;
+    } else if backups_disabled && !is_dry_run {
+        // Backups were explicitly disabled
+        output.blank_line()?;
+        output.plain(&format!("  Backup created: {}", style("No (disabled)").yellow()))?;
+        output.warning("⚠ No backup created. Use Git to rollback if needed.")?;
     }
 
     if is_dry_run {

--- a/crates/pkg/SPEC.md
+++ b/crates/pkg/SPEC.md
@@ -1822,9 +1822,10 @@ impl UpgradeManager {
     ) -> Result<Vec<PackageUpgrades>>;
     
     pub async fn apply_upgrades(
-        &self,
+        &mut self,
         selection: UpgradeSelection,
         dry_run: bool,
+        backup_enabled: Option<bool>,
     ) -> Result<UpgradeResult>;
     
     pub async fn apply_with_changeset(
@@ -1838,6 +1839,13 @@ impl UpgradeManager {
 }
 ```
 
+**Parameters:**
+
+- `backup_enabled` (optional): Override for backup creation behavior
+  - `None`: Uses the configured backup setting from `PackageToolsConfig`
+  - `Some(true)`: Forces backup creation regardless of configuration
+  - `Some(false)`: Skips backup creation regardless of configuration
+
 **Example:**
 ```rust
 use sublime_pkg_tools::upgrade::{UpgradeManager, DetectionOptions, UpgradeSelection};
@@ -1849,17 +1857,27 @@ let workspace_root = PathBuf::from(".");
 let fs = FileSystemManager::new();
 let config = PackageToolsConfig::default();
 
-let manager = UpgradeManager::new(workspace_root, fs, config).await?;
+let mut manager = UpgradeManager::new(workspace_root, fs, config).await?;
 
 // Detect upgrades
 let options = DetectionOptions::all();
 let available = manager.detect_upgrades(options).await?;
 println!("Found {} packages with upgrades", available.len());
 
-// Apply patch upgrades
+// Apply patch upgrades with default backup behavior (from config)
 let selection = UpgradeSelection::patch_only();
-let result = manager.apply_upgrades(selection, false).await?;
+let result = manager.apply_upgrades(selection, false, None).await?;
 println!("Applied {} upgrades", result.applied.len());
+
+// Apply upgrades without backups (CI/CD scenario)
+let selection = UpgradeSelection::all();
+let result = manager.apply_upgrades(selection, false, Some(false)).await?;
+println!("Applied {} upgrades without backup", result.applied.len());
+
+// Apply upgrades with forced backup
+let selection = UpgradeSelection::minor_and_patch();
+let result = manager.apply_upgrades(selection, false, Some(true)).await?;
+println!("Applied {} upgrades with backup: {:?}", result.applied.len(), result.backup_path);
 ```
 
 ### RegistryClient

--- a/crates/pkg/src/upgrade/manager.rs
+++ b/crates/pkg/src/upgrade/manager.rs
@@ -172,7 +172,7 @@ impl UpgradeManager {
     /// Applies selected upgrades to package.json files.
     ///
     /// This is the main method for applying dependency upgrades. It:
-    /// 1. Creates automatic backups (if configured)
+    /// 1. Creates automatic backups (if configured and not overridden)
     /// 2. Applies the selected upgrades to package.json files
     /// 3. Creates or updates a changeset (if configured)
     /// 4. Cleans up backups on success (if configured)
@@ -186,6 +186,9 @@ impl UpgradeManager {
     ///
     /// * `selection` - Selection criteria for filtering which upgrades to apply
     /// * `dry_run` - If true, preview changes without modifying files
+    /// * `backup_enabled` - Optional override for backup creation. If `None`, uses config value.
+    ///   If `Some(false)`, skips backup creation regardless of config.
+    ///   If `Some(true)`, forces backup creation regardless of config.
     ///
     /// # Returns
     ///
@@ -195,31 +198,39 @@ impl UpgradeManager {
     /// # Errors
     ///
     /// Returns `UpgradeError` if:
-    /// - Backup creation fails
+    /// - Backup creation fails (when backups are enabled)
     /// - Files cannot be read or written
     /// - Changeset creation fails
     /// - JSON parsing fails
     ///
-    /// On error, any changes are automatically rolled back from the backup.
+    /// On error, any changes are automatically rolled back from the backup (if backup was created).
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```rust,ignore
     /// use sublime_pkg_tools::upgrade::UpgradeSelection;
     ///
-    /// # async fn example(manager: sublime_pkg_tools::upgrade::UpgradeManager) -> Result<(), Box<dyn std::error::Error>> {
-    /// // Preview changes (dry-run)
-    /// let preview = manager.apply_upgrades(UpgradeSelection::all(), true).await?;
+    /// # async fn example(mut manager: sublime_pkg_tools::upgrade::UpgradeManager) -> Result<(), Box<dyn std::error::Error>> {
+    /// // Preview changes (dry-run) - no backups created
+    /// let preview = manager.apply_upgrades(UpgradeSelection::all(), true, None).await?;
     /// println!("Would upgrade {} dependencies", preview.summary.dependencies_upgraded);
     ///
-    /// // Apply patch upgrades only
-    /// let result = manager.apply_upgrades(UpgradeSelection::patch_only(), false).await?;
+    /// // Apply with default backup behavior from config
+    /// let result = manager.apply_upgrades(UpgradeSelection::patch_only(), false, None).await?;
     /// println!("Applied {} patch upgrades", result.summary.patch_upgrades);
     ///
-    /// // Apply specific dependencies
+    /// // Apply without backups (CI/CD scenario)
+    /// let result = manager.apply_upgrades(
+    ///     UpgradeSelection::all(),
+    ///     false,
+    ///     Some(false) // Explicitly disable backups
+    /// ).await?;
+    ///
+    /// // Apply with forced backups
     /// let result = manager.apply_upgrades(
     ///     UpgradeSelection::dependencies(vec!["lodash".to_string()]),
-    ///     false
+    ///     false,
+    ///     Some(true) // Explicitly enable backups
     /// ).await?;
     /// # Ok(())
     /// # }
@@ -228,6 +239,7 @@ impl UpgradeManager {
         &mut self,
         selection: UpgradeSelection,
         dry_run: bool,
+        backup_enabled: Option<bool>,
     ) -> UpgradeResult<UpgradeResultType> {
         // First, detect available upgrades
         let detection_options = self.selection_to_detection_options(&selection);
@@ -242,8 +254,11 @@ impl UpgradeManager {
             return apply_upgrades(preview.packages, selection, dry_run, &self.fs).await;
         }
 
+        // Determine effective backup setting (override takes precedence over config)
+        let should_backup = backup_enabled.unwrap_or(self.config.backup.enabled);
+
         // Create backup if enabled
-        let backup_id = if self.config.backup.enabled {
+        let backup_id = if should_backup {
             let files_to_backup = self.collect_package_json_files(&preview.packages)?;
             let backup_id = self.backup_manager.create_backup(&files_to_backup, "upgrade").await?;
             Some(backup_id)
@@ -286,23 +301,23 @@ impl UpgradeManager {
                     self.last_backup_id = Some(id.clone());
                 }
 
-                // Clean up backup if configured
-                if self.config.backup.enabled
+                // Clean up backup if configured (only if backup was actually created)
+                if should_backup
                     && !self.config.backup.keep_after_success
                     && let Some(id) = backup_id
                 {
                     let _ = self.backup_manager.delete_backup(&id).await;
                 }
 
-                // Clean up old backups
-                if self.config.backup.enabled {
+                // Clean up old backups (only if backups are enabled)
+                if should_backup {
                     let _ = self.backup_manager.cleanup_old_backups().await;
                 }
 
                 Ok(upgrade_result)
             }
             Err(e) => {
-                // Rollback on failure
+                // Rollback on failure (only if backup was created)
                 if let Some(id) = backup_id {
                     let _ = self.backup_manager.restore_backup(&id).await;
                     self.last_backup_id = Some(id);
@@ -335,7 +350,8 @@ impl UpgradeManager {
     /// // Apply upgrades
     /// let result = manager.apply_upgrades(
     ///     sublime_pkg_tools::upgrade::UpgradeSelection::all(),
-    ///     false
+    ///     false,
+    ///     None
     /// ).await?;
     ///
     /// // Later, if issues are discovered...
@@ -461,12 +477,4 @@ impl UpgradeManager {
     ) -> UpgradeResult<Vec<PathBuf>> {
         Ok(packages.iter().map(|pkg| pkg.package_path.join("package.json")).collect())
     }
-}
-
-#[cfg(test)]
-mod tests {
-    // Note: Full integration tests should be in the tests/ directory
-    // Unit tests for internal helper methods would go here, but the current
-    // implementation doesn't have testable private methods that warrant unit tests.
-    // The public API is better tested through integration tests with real fixtures.
 }

--- a/crates/pkg/src/upgrade/mod.rs
+++ b/crates/pkg/src/upgrade/mod.rs
@@ -223,3 +223,7 @@ mod manager;
 
 // Re-export manager public types
 pub use manager::UpgradeManager;
+
+// Tests module
+#[cfg(test)]
+mod tests;

--- a/crates/pkg/src/upgrade/tests.rs
+++ b/crates/pkg/src/upgrade/tests.rs
@@ -1,0 +1,83 @@
+//! Tests for upgrade manager functionality.
+
+#![allow(clippy::unwrap_used)]
+
+use crate::config::BackupConfig;
+
+/// Helper function to determine effective backup setting.
+fn determine_backup_setting(override_value: Option<bool>, config_value: bool) -> bool {
+    override_value.unwrap_or(config_value)
+}
+
+/// Tests that backup_enabled parameter correctly overrides config.
+#[test]
+fn test_backup_enabled_override_logic() {
+    // Test with backup disabled in config
+    let config_backup_disabled = false;
+
+    // Override: None -> should use config (false)
+    let effective = determine_backup_setting(None, config_backup_disabled);
+    assert!(!effective, "None override should use config value (false)");
+
+    // Override: Some(true) -> should override to true
+    let effective = determine_backup_setting(Some(true), config_backup_disabled);
+    assert!(effective, "Some(true) override should force backup enabled");
+
+    // Override: Some(false) -> should override to false
+    let effective = determine_backup_setting(Some(false), config_backup_disabled);
+    assert!(!effective, "Some(false) override should force backup disabled");
+}
+
+/// Tests backup control with backups enabled in config.
+#[test]
+fn test_backup_enabled_in_config_logic() {
+    // Test with backup enabled in config
+    let config_backup_enabled = true;
+
+    // Override: None -> should use config (true)
+    let effective = determine_backup_setting(None, config_backup_enabled);
+    assert!(effective, "None override should use config value (true)");
+
+    // Override: Some(true) -> should remain true
+    let effective = determine_backup_setting(Some(true), config_backup_enabled);
+    assert!(effective, "Some(true) override should keep backup enabled");
+
+    // Override: Some(false) -> should override to false
+    let effective = determine_backup_setting(Some(false), config_backup_enabled);
+    assert!(!effective, "Some(false) override should disable backup despite config");
+}
+
+/// Tests that cleanup operations respect the effective backup setting.
+#[test]
+fn test_cleanup_respects_backup_setting_logic() {
+    // Verify that backup cleanup only happens when backups are enabled
+    let config_with_backup = BackupConfig {
+        enabled: true,
+        backup_dir: ".workspace-backups".to_string(),
+        keep_after_success: false,
+        max_backups: 10,
+    };
+
+    let config_without_backup = BackupConfig {
+        enabled: false,
+        backup_dir: ".workspace-backups".to_string(),
+        keep_after_success: false,
+        max_backups: 10,
+    };
+
+    // When backups are enabled, cleanup should happen
+    let should_cleanup = config_with_backup.enabled && !config_with_backup.keep_after_success;
+    assert!(
+        should_cleanup,
+        "Cleanup should occur when backups enabled and keep_after_success is false"
+    );
+
+    // When backups are disabled, cleanup should not happen
+    let should_cleanup = config_without_backup.enabled && !config_without_backup.keep_after_success;
+    assert!(!should_cleanup, "Cleanup should not occur when backups disabled");
+
+    // Test override scenario: backup disabled via parameter
+    let effective_backup = determine_backup_setting(Some(false), config_with_backup.enabled);
+    let should_cleanup = effective_backup && !config_with_backup.keep_after_success;
+    assert!(!should_cleanup, "Cleanup should not occur when backup disabled via override");
+}


### PR DESCRIPTION

Add optional backup_enabled parameter to UpgradeManager::apply_upgrades() allowing users to skip backup creation via --no-backup CLI flag.

Changes:
- Add backup_enabled parameter to UpgradeManager::apply_upgrades()
- Connect --no-backup CLI flag to backup control logic
- Add warning messages when backups are disabled
- Update help text with detailed guidance and use cases
- Add unit tests for backup override logic in tests.rs
- Update SPEC.md with API documentation and examples
- Update README.md with usage examples and warnings

BREAKING CHANGE: UpgradeManager::apply_upgrades() signature changed
- Old: apply_upgrades(selection, dry_run)
- New: apply_upgrades(selection, dry_run, backup_enabled)

The backup_enabled parameter accepts:
- None: uses config default
- Some(true): forces backup creation
- Some(false): skips backup creation

Recommended for CI/CD pipelines and Git-based workflows.