### PR TITLE
feat(WOR-TSK-177): implement status types for NAPI Node.js bindings

### DIFF
--- a/crates/node/Cargo.lock
+++ b/crates/node/Cargo.lock
@@ -2065,7 +2065,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sublime_cli_tools"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2096,12 +2096,13 @@ dependencies = [
 
 [[package]]
 name = "sublime_git_tools"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
  "git2",
  "libgit2-sys",
+ "libz-sys",
  "serde",
  "thiserror 1.0.69",
 ]
@@ -2128,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "sublime_pkg_tools"
-version = "0.0.18"
+version = "0.0.19"
 dependencies = [
  "async-trait",
  "base64 0.21.7",

--- a/crates/node/src/tests.rs
+++ b/crates/node/src/tests.rs
@@ -1414,3 +1414,460 @@ mod types_tests {
         assert!(!response.is_error());
     }
 }
+
+/// Tests for status types (Story 3.1).
+///
+/// These tests verify that the status command types are correctly defined
+/// and can be used for parameter validation and response construction.
+mod status_types_tests {
+    use crate::types::status::{
+        BranchInfo, ChangesetInfo, PackageInfo, PackageManagerInfo, RepositoryInfo, StatusData,
+        StatusParams,
+    };
+
+    // ========================================================================
+    // StatusParams Tests
+    // ========================================================================
+
+    #[test]
+    fn test_status_params_new() {
+        let params = StatusParams::new("/path/to/workspace");
+        assert_eq!(params.root, "/path/to/workspace");
+        assert!(params.config_path.is_none());
+    }
+
+    #[test]
+    fn test_status_params_with_config() {
+        let params = StatusParams::with_config("/path/to/workspace", "/path/to/config.json");
+        assert_eq!(params.root, "/path/to/workspace");
+        assert_eq!(params.config_path, Some("/path/to/config.json".to_string()));
+    }
+
+    #[test]
+    fn test_status_params_clone() {
+        let params = StatusParams::with_config("/workspace", "/config.json");
+        let cloned = params.clone();
+        assert_eq!(cloned.root, params.root);
+        assert_eq!(cloned.config_path, params.config_path);
+    }
+
+    #[test]
+    fn test_status_params_debug() {
+        let params = StatusParams::new("/workspace");
+        let debug_str = format!("{params:?}");
+        assert!(debug_str.contains("StatusParams"));
+        assert!(debug_str.contains("/workspace"));
+    }
+
+    #[test]
+    fn test_status_params_serialize() {
+        let params = StatusParams::with_config("/workspace", "/config.json");
+        let json = serde_json::to_string(&params).unwrap_or_default();
+        assert!(json.contains("\"root\":\"/workspace\""));
+        assert!(json.contains("\"config_path\":\"/config.json\""));
+    }
+
+    // ========================================================================
+    // RepositoryInfo Tests
+    // ========================================================================
+
+    #[test]
+    fn test_repository_info_simple() {
+        let info = RepositoryInfo::simple();
+        assert_eq!(info.kind, "simple");
+        assert!(info.monorepo_type.is_none());
+        assert!(info.is_simple());
+        assert!(!info.is_monorepo());
+    }
+
+    #[test]
+    fn test_repository_info_monorepo() {
+        let info = RepositoryInfo::monorepo("pnpm");
+        assert_eq!(info.kind, "monorepo");
+        assert_eq!(info.monorepo_type, Some("pnpm".to_string()));
+        assert!(!info.is_simple());
+        assert!(info.is_monorepo());
+    }
+
+    #[test]
+    fn test_repository_info_monorepo_types() {
+        let npm = RepositoryInfo::monorepo("npm");
+        assert_eq!(npm.monorepo_type, Some("npm".to_string()));
+
+        let yarn = RepositoryInfo::monorepo("yarn");
+        assert_eq!(yarn.monorepo_type, Some("yarn".to_string()));
+
+        let bun = RepositoryInfo::monorepo("bun");
+        assert_eq!(bun.monorepo_type, Some("bun".to_string()));
+
+        let deno = RepositoryInfo::monorepo("deno");
+        assert_eq!(deno.monorepo_type, Some("deno".to_string()));
+
+        let custom = RepositoryInfo::monorepo("custom");
+        assert_eq!(custom.monorepo_type, Some("custom".to_string()));
+    }
+
+    #[test]
+    fn test_repository_info_unknown() {
+        let info = RepositoryInfo::unknown();
+        assert_eq!(info.kind, "unknown");
+        assert!(info.monorepo_type.is_none());
+        assert!(!info.is_simple());
+        assert!(!info.is_monorepo());
+    }
+
+    #[test]
+    fn test_repository_info_clone() {
+        let info = RepositoryInfo::monorepo("pnpm");
+        let cloned = info.clone();
+        assert_eq!(cloned.kind, info.kind);
+        assert_eq!(cloned.monorepo_type, info.monorepo_type);
+    }
+
+    #[test]
+    fn test_repository_info_serialize() {
+        let info = RepositoryInfo::monorepo("pnpm");
+        let json = serde_json::to_string(&info).unwrap_or_default();
+        assert!(json.contains("\"kind\":\"monorepo\""));
+        assert!(json.contains("\"monorepo_type\":\"pnpm\""));
+    }
+
+    #[test]
+    fn test_repository_info_serialize_simple() {
+        let info = RepositoryInfo::simple();
+        let json = serde_json::to_string(&info).unwrap_or_default();
+        assert!(json.contains("\"kind\":\"simple\""));
+        // monorepo_type should not be present when None
+        assert!(!json.contains("monorepo_type"));
+    }
+
+    // ========================================================================
+    // PackageManagerInfo Tests
+    // ========================================================================
+
+    #[test]
+    fn test_package_manager_info_new() {
+        let info = PackageManagerInfo::new("pnpm", "pnpm-lock.yaml");
+        assert_eq!(info.name, "pnpm");
+        assert_eq!(info.lock_file, "pnpm-lock.yaml");
+    }
+
+    #[test]
+    fn test_package_manager_info_npm() {
+        let info = PackageManagerInfo::npm();
+        assert_eq!(info.name, "npm");
+        assert_eq!(info.lock_file, "package-lock.json");
+    }
+
+    #[test]
+    fn test_package_manager_info_yarn() {
+        let info = PackageManagerInfo::yarn();
+        assert_eq!(info.name, "yarn");
+        assert_eq!(info.lock_file, "yarn.lock");
+    }
+
+    #[test]
+    fn test_package_manager_info_pnpm() {
+        let info = PackageManagerInfo::pnpm();
+        assert_eq!(info.name, "pnpm");
+        assert_eq!(info.lock_file, "pnpm-lock.yaml");
+    }
+
+    #[test]
+    fn test_package_manager_info_bun() {
+        let info = PackageManagerInfo::bun();
+        assert_eq!(info.name, "bun");
+        assert_eq!(info.lock_file, "bun.lockb");
+    }
+
+    #[test]
+    fn test_package_manager_info_unknown() {
+        let info = PackageManagerInfo::unknown();
+        assert_eq!(info.name, "unknown");
+        assert_eq!(info.lock_file, "");
+    }
+
+    #[test]
+    fn test_package_manager_info_clone() {
+        let info = PackageManagerInfo::pnpm();
+        let cloned = info.clone();
+        assert_eq!(cloned.name, info.name);
+        assert_eq!(cloned.lock_file, info.lock_file);
+    }
+
+    #[test]
+    fn test_package_manager_info_serialize() {
+        let info = PackageManagerInfo::pnpm();
+        let json = serde_json::to_string(&info).unwrap_or_default();
+        assert!(json.contains("\"name\":\"pnpm\""));
+        assert!(json.contains("\"lock_file\":\"pnpm-lock.yaml\""));
+    }
+
+    // ========================================================================
+    // BranchInfo Tests
+    // ========================================================================
+
+    #[test]
+    fn test_branch_info_new() {
+        let branch = BranchInfo::new("main");
+        assert_eq!(branch.name, "main");
+    }
+
+    #[test]
+    fn test_branch_info_feature_branch() {
+        let branch = BranchInfo::new("feature/add-login");
+        assert_eq!(branch.name, "feature/add-login");
+    }
+
+    #[test]
+    fn test_branch_info_clone() {
+        let branch = BranchInfo::new("develop");
+        let cloned = branch.clone();
+        assert_eq!(cloned.name, branch.name);
+    }
+
+    #[test]
+    fn test_branch_info_serialize() {
+        let branch = BranchInfo::new("main");
+        let json = serde_json::to_string(&branch).unwrap_or_default();
+        assert!(json.contains("\"name\":\"main\""));
+    }
+
+    // ========================================================================
+    // ChangesetInfo Tests
+    // ========================================================================
+
+    #[test]
+    fn test_changeset_info_new() {
+        let changeset = ChangesetInfo::new("feature-login");
+        assert_eq!(changeset.id, "feature-login");
+    }
+
+    #[test]
+    fn test_changeset_info_with_slashes() {
+        let changeset = ChangesetInfo::new("feature/add-new-api");
+        assert_eq!(changeset.id, "feature/add-new-api");
+    }
+
+    #[test]
+    fn test_changeset_info_clone() {
+        let changeset = ChangesetInfo::new("fix-bug");
+        let cloned = changeset.clone();
+        assert_eq!(cloned.id, changeset.id);
+    }
+
+    #[test]
+    fn test_changeset_info_serialize() {
+        let changeset = ChangesetInfo::new("feature-login");
+        let json = serde_json::to_string(&changeset).unwrap_or_default();
+        assert!(json.contains("\"id\":\"feature-login\""));
+    }
+
+    // ========================================================================
+    // PackageInfo Tests
+    // ========================================================================
+
+    #[test]
+    fn test_package_info_new() {
+        let pkg = PackageInfo::new("@org/core", "1.2.3", "packages/core");
+        assert_eq!(pkg.name, "@org/core");
+        assert_eq!(pkg.version, "1.2.3");
+        assert_eq!(pkg.path, "packages/core");
+    }
+
+    #[test]
+    fn test_package_info_unscoped() {
+        let pkg = PackageInfo::new("utils", "0.1.0", "packages/utils");
+        assert_eq!(pkg.name, "utils");
+        assert_eq!(pkg.version, "0.1.0");
+        assert_eq!(pkg.path, "packages/utils");
+    }
+
+    #[test]
+    fn test_package_info_root_path() {
+        let pkg = PackageInfo::new("my-package", "1.0.0", ".");
+        assert_eq!(pkg.path, ".");
+    }
+
+    #[test]
+    fn test_package_info_prerelease_version() {
+        let pkg = PackageInfo::new("@org/core", "1.0.0-beta.1", "packages/core");
+        assert_eq!(pkg.version, "1.0.0-beta.1");
+    }
+
+    #[test]
+    fn test_package_info_clone() {
+        let pkg = PackageInfo::new("@org/core", "1.2.3", "packages/core");
+        let cloned = pkg.clone();
+        assert_eq!(cloned.name, pkg.name);
+        assert_eq!(cloned.version, pkg.version);
+        assert_eq!(cloned.path, pkg.path);
+    }
+
+    #[test]
+    fn test_package_info_serialize() {
+        let pkg = PackageInfo::new("@org/core", "1.2.3", "packages/core");
+        let json = serde_json::to_string(&pkg).unwrap_or_default();
+        assert!(json.contains("\"name\":\"@org/core\""));
+        assert!(json.contains("\"version\":\"1.2.3\""));
+        assert!(json.contains("\"path\":\"packages/core\""));
+    }
+
+    // ========================================================================
+    // StatusData Tests
+    // ========================================================================
+
+    #[test]
+    fn test_status_data_new() {
+        let data = StatusData::new(RepositoryInfo::simple(), PackageManagerInfo::pnpm());
+        assert!(data.repository.is_simple());
+        assert_eq!(data.package_manager.name, "pnpm");
+        assert!(data.branch.is_none());
+        assert!(data.changesets.is_empty());
+        assert!(data.packages.is_empty());
+    }
+
+    #[test]
+    fn test_status_data_with_branch() {
+        let data = StatusData::new(RepositoryInfo::simple(), PackageManagerInfo::pnpm())
+            .with_branch(BranchInfo::new("main"));
+        assert!(data.branch.is_some());
+        assert_eq!(data.branch.as_ref().map(|b| b.name.as_str()), Some("main"));
+    }
+
+    #[test]
+    fn test_status_data_with_changesets() {
+        let changesets = vec![ChangesetInfo::new("feature-a"), ChangesetInfo::new("feature-b")];
+        let data = StatusData::new(RepositoryInfo::simple(), PackageManagerInfo::pnpm())
+            .with_changesets(changesets);
+        assert_eq!(data.changesets.len(), 2);
+        assert_eq!(data.changesets[0].id, "feature-a");
+        assert_eq!(data.changesets[1].id, "feature-b");
+    }
+
+    #[test]
+    fn test_status_data_with_packages() {
+        let packages = vec![
+            PackageInfo::new("@org/core", "1.0.0", "packages/core"),
+            PackageInfo::new("@org/utils", "0.5.0", "packages/utils"),
+        ];
+        let data = StatusData::new(RepositoryInfo::monorepo("pnpm"), PackageManagerInfo::pnpm())
+            .with_packages(packages);
+        assert_eq!(data.packages.len(), 2);
+        assert_eq!(data.packages[0].name, "@org/core");
+        assert_eq!(data.packages[1].name, "@org/utils");
+    }
+
+    #[test]
+    fn test_status_data_builder_chain() {
+        let data = StatusData::new(RepositoryInfo::monorepo("pnpm"), PackageManagerInfo::pnpm())
+            .with_branch(BranchInfo::new("main"))
+            .with_changesets(vec![ChangesetInfo::new("feature-x")])
+            .with_packages(vec![PackageInfo::new("@org/core", "1.0.0", "packages/core")]);
+
+        assert!(data.repository.is_monorepo());
+        assert_eq!(data.repository.monorepo_type, Some("pnpm".to_string()));
+        assert_eq!(data.package_manager.name, "pnpm");
+        assert!(data.branch.is_some());
+        assert_eq!(data.changesets.len(), 1);
+        assert_eq!(data.packages.len(), 1);
+    }
+
+    #[test]
+    fn test_status_data_clone() {
+        let data = StatusData::new(RepositoryInfo::monorepo("pnpm"), PackageManagerInfo::pnpm())
+            .with_branch(BranchInfo::new("main"))
+            .with_packages(vec![PackageInfo::new("@org/core", "1.0.0", "packages/core")]);
+
+        let cloned = data.clone();
+        assert_eq!(cloned.repository.kind, data.repository.kind);
+        assert_eq!(cloned.package_manager.name, data.package_manager.name);
+        assert_eq!(
+            cloned.branch.as_ref().map(|b| b.name.as_str()),
+            data.branch.as_ref().map(|b| b.name.as_str())
+        );
+        assert_eq!(cloned.packages.len(), data.packages.len());
+    }
+
+    #[test]
+    fn test_status_data_serialize() {
+        let data = StatusData::new(RepositoryInfo::monorepo("pnpm"), PackageManagerInfo::pnpm())
+            .with_branch(BranchInfo::new("main"))
+            .with_changesets(vec![ChangesetInfo::new("feature-x")])
+            .with_packages(vec![PackageInfo::new("@org/core", "1.0.0", "packages/core")]);
+
+        let json = serde_json::to_string(&data).unwrap_or_default();
+        assert!(json.contains("\"kind\":\"monorepo\""));
+        assert!(json.contains("\"monorepo_type\":\"pnpm\""));
+        assert!(json.contains("\"name\":\"pnpm\""));
+        assert!(json.contains("\"name\":\"main\""));
+        assert!(json.contains("\"id\":\"feature-x\""));
+        assert!(json.contains("\"name\":\"@org/core\""));
+    }
+
+    #[test]
+    fn test_status_data_serialize_without_optional_fields() {
+        let data = StatusData::new(RepositoryInfo::simple(), PackageManagerInfo::npm());
+
+        let json = serde_json::to_string(&data).unwrap_or_default();
+        assert!(json.contains("\"kind\":\"simple\""));
+        // branch should not be present when None
+        assert!(!json.contains("\"branch\":null"));
+        // changesets and packages should be empty arrays
+        assert!(json.contains("\"changesets\":[]"));
+        assert!(json.contains("\"packages\":[]"));
+    }
+
+    // ========================================================================
+    // Integration-style Tests
+    // ========================================================================
+
+    #[test]
+    fn test_complete_status_response_simple_repo() {
+        let data = StatusData::new(RepositoryInfo::simple(), PackageManagerInfo::npm())
+            .with_branch(BranchInfo::new("main"))
+            .with_packages(vec![PackageInfo::new("my-app", "1.0.0", ".")]);
+
+        assert!(data.repository.is_simple());
+        assert!(!data.repository.is_monorepo());
+        assert_eq!(data.package_manager.name, "npm");
+        assert_eq!(data.package_manager.lock_file, "package-lock.json");
+        assert_eq!(data.branch.as_ref().map(|b| b.name.as_str()), Some("main"));
+        assert!(data.changesets.is_empty());
+        assert_eq!(data.packages.len(), 1);
+        assert_eq!(data.packages[0].path, ".");
+    }
+
+    #[test]
+    fn test_complete_status_response_monorepo() {
+        let data = StatusData::new(RepositoryInfo::monorepo("pnpm"), PackageManagerInfo::pnpm())
+            .with_branch(BranchInfo::new("develop"))
+            .with_changesets(vec![
+                ChangesetInfo::new("feature/add-auth"),
+                ChangesetInfo::new("fix/memory-leak"),
+            ])
+            .with_packages(vec![
+                PackageInfo::new("@myorg/core", "2.0.0", "packages/core"),
+                PackageInfo::new("@myorg/utils", "1.5.0", "packages/utils"),
+                PackageInfo::new("@myorg/cli", "1.0.0-beta.1", "packages/cli"),
+            ]);
+
+        assert!(data.repository.is_monorepo());
+        assert_eq!(data.repository.monorepo_type, Some("pnpm".to_string()));
+        assert_eq!(data.package_manager.name, "pnpm");
+        assert_eq!(data.package_manager.lock_file, "pnpm-lock.yaml");
+        assert_eq!(data.branch.as_ref().map(|b| b.name.as_str()), Some("develop"));
+        assert_eq!(data.changesets.len(), 2);
+        assert_eq!(data.packages.len(), 3);
+    }
+
+    #[test]
+    fn test_status_response_without_git() {
+        // Simulate a response when Git is not available
+        let data = StatusData::new(RepositoryInfo::simple(), PackageManagerInfo::npm())
+            .with_packages(vec![PackageInfo::new("my-package", "1.0.0", ".")]);
+
+        assert!(data.branch.is_none());
+        assert!(data.changesets.is_empty());
+    }
+}

--- a/crates/node/src/types/mod.rs
+++ b/crates/node/src/types/mod.rs
@@ -54,8 +54,16 @@
 //! };
 //! ```
 
-// TODO: will be implemented on story 3.1 (status types)
+// Status types (Story 3.1 - Implemented)
 pub(crate) mod status;
+
+// Re-export status types for easier access
+// Allow unused imports until Story 3.2 implements the status command
+#[allow(unused_imports)]
+pub(crate) use status::{
+    BranchInfo, ChangesetInfo, PackageInfo, PackageManagerInfo, RepositoryInfo, StatusData,
+    StatusParams,
+};
 
 // TODO: will be implemented on story 3.3 (init types)
 pub(crate) mod init;

--- a/crates/node/src/types/status.rs
+++ b/crates/node/src/types/status.rs
@@ -1,42 +1,885 @@
-//! Status command type definitions.
+//! Status command type definitions for Node.js bindings.
 //!
 //! # What
 //!
-//! This module contains type definitions for the status command, including
-//! parameter structures and response data types.
+//! This module defines all NAPI-compatible type structures for the status command,
+//! including input parameters and response data types. These types enable JavaScript
+//! and TypeScript consumers to interact with workspace status information in a
+//! type-safe manner.
 //!
 //! # How
 //!
-//! Types are defined with `#[napi(object)]` attribute to be exposed as
-//! JavaScript objects. The module provides:
+//! Types are defined with the `#[napi(object)]` attribute to be automatically
+//! exposed as JavaScript objects. The module provides:
 //!
-//! - `StatusParams`: Input parameters for the status command
-//! - `StatusData`: Response data containing workspace status information
+//! - **`StatusParams`**: Input parameters for the status command
+//! - **`StatusData`**: Response data containing comprehensive workspace status
+//! - **`RepositoryInfo`**: Repository type and monorepo information
+//! - **`PackageManagerInfo`**: Package manager and lock file details
+//! - **`BranchInfo`**: Current Git branch information
+//! - **`ChangesetInfo`**: Pending changeset details
+//! - **`PackageInfo`**: Individual package metadata
+//!
+//! All types implement `Clone`, `Debug`, and `Serialize` for flexibility in
+//! testing and serialization scenarios.
 //!
 //! # Why
 //!
 //! The status command is a fundamental operation that retrieves information
-//! about the current workspace state, including package information, git
-//! status, and configuration details.
+//! about the current workspace state. These types provide:
+//!
+//! - **Type safety**: Strong typing for JavaScript/TypeScript consumers
+//! - **Documentation**: Self-documenting API through TypeScript definitions
+//! - **Consistency**: Matches the CLI JSON output structure for compatibility
+//! - **Validation**: Enables parameter validation before CLI execution
 //!
 //! # Examples
+//!
+//! ## TypeScript Usage
 //!
 //! ```typescript
 //! import { status, StatusParams, StatusData } from '@websublime/workspace-tools';
 //!
-//! const params: StatusParams = { root: '.' };
+//! const params: StatusParams = {
+//!   root: '/path/to/workspace',
+//!   configPath: '/path/to/repo.config.json' // optional
+//! };
+//!
 //! const result = await status(params);
 //!
 //! if (result.success) {
 //!   const data: StatusData = result.data;
-//!   console.log(`Repository: ${data.repository}`);
-//!   console.log(`Package Manager: ${data.packageManager}`);
-//!   console.log(`Packages: ${data.packages.length}`);
+//!   console.log(`Repository kind: ${data.repository.kind}`);
+//!   console.log(`Package manager: ${data.packageManager.name}`);
+//!   console.log(`Lock file: ${data.packageManager.lockFile}`);
+//!
+//!   if (data.branch) {
+//!     console.log(`Current branch: ${data.branch.name}`);
+//!   }
+//!
+//!   console.log(`Pending changesets: ${data.changesets.length}`);
+//!   console.log(`Packages:`);
+//!   for (const pkg of data.packages) {
+//!     console.log(`  - ${pkg.name}@${pkg.version} (${pkg.path})`);
+//!   }
 //! }
 //! ```
+//!
+//! ## Rust Usage (Internal)
+//!
+//! ```rust,ignore
+//! use sublime_node_tools::types::status::{StatusParams, StatusData, RepositoryInfo};
+//!
+//! // Creating params for validation
+//! let params = StatusParams {
+//!     root: "/path/to/workspace".to_string(),
+//!     config_path: None,
+//! };
+//!
+//! // Constructing response data
+//! let data = StatusData {
+//!     repository: RepositoryInfo {
+//!         kind: "monorepo".to_string(),
+//!         monorepo_type: Some("pnpm".to_string()),
+//!     },
+//!     package_manager: PackageManagerInfo {
+//!         name: "pnpm".to_string(),
+//!         lock_file: "pnpm-lock.yaml".to_string(),
+//!     },
+//!     branch: Some(BranchInfo { name: "main".to_string() }),
+//!     changesets: vec![],
+//!     packages: vec![],
+//! };
+//! ```
 
-// TODO: will be implemented on story 3.1 - Status Types
-// This module will contain:
-// - StatusParams: { root: string }
-// - StatusData: { repository, packageManager, branch, packages, ... }
-// - PackageStatusInfo: Extended package information with status details
+use napi_derive::napi;
+use serde::Serialize;
+
+// ============================================================================
+// Input Parameters
+// ============================================================================
+
+/// Input parameters for the status command.
+///
+/// This structure defines the parameters that can be passed to the `status`
+/// function from JavaScript/TypeScript. The root path is required, while
+/// the config path is optional.
+///
+/// # Fields
+///
+/// - `root`: The workspace root directory path (required)
+/// - `config_path`: Optional path to a custom configuration file
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface StatusParams {
+///   /** Workspace root directory path */
+///   root: string;
+///   /** Optional custom config file path */
+///   configPath?: string;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// // Minimal params with just root
+/// const params: StatusParams = { root: '.' };
+///
+/// // With custom config path
+/// const paramsWithConfig: StatusParams = {
+///   root: '/path/to/workspace',
+///   configPath: '/path/to/custom/repo.config.json'
+/// };
+/// ```
+// Allow dead_code until Story 3.2 implements the status command
+#[allow(dead_code)]
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct StatusParams {
+    /// Workspace root directory path.
+    ///
+    /// This is the absolute or relative path to the root of the workspace.
+    /// For monorepos, this should point to the root where the package manager
+    /// configuration (e.g., `pnpm-workspace.yaml`) is located.
+    pub root: String,
+
+    /// Optional custom configuration file path.
+    ///
+    /// If not provided, the command will search for configuration files
+    /// in standard locations (`repo.config.json`, `repo.config.yaml`, etc.)
+    /// within the workspace root.
+    #[napi(ts_type = "string | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_path: Option<String>,
+}
+
+// ============================================================================
+// Response Data Types
+// ============================================================================
+
+/// Repository type information.
+///
+/// Contains information about the repository structure, indicating whether
+/// it's a simple single-package repository or a monorepo with multiple packages.
+///
+/// # Fields
+///
+/// - `kind`: The repository type ("simple", "monorepo", or "unknown")
+/// - `monorepo_type`: The monorepo type if applicable
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface RepositoryInfo {
+///   /** Repository kind: "simple", "monorepo", or "unknown" */
+///   kind: string;
+///   /** Monorepo type if applicable (npm, yarn, pnpm, bun, deno, custom) */
+///   monorepoType?: string;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// // Simple repository (single package)
+/// const simple: RepositoryInfo = { kind: 'simple' };
+///
+/// // Monorepo with pnpm workspaces
+/// const monorepo: RepositoryInfo = {
+///   kind: 'monorepo',
+///   monorepoType: 'pnpm'
+/// };
+/// ```
+// Allow dead_code until Story 3.2 implements the status command
+#[allow(dead_code)]
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct RepositoryInfo {
+    /// Repository kind identifier.
+    ///
+    /// Possible values:
+    /// - `"simple"`: Single package repository
+    /// - `"monorepo"`: Multi-package workspace
+    /// - `"unknown"`: Unable to determine repository type
+    pub kind: String,
+
+    /// Monorepo type if the repository is a monorepo.
+    ///
+    /// This field is only present when `kind` is `"monorepo"`.
+    /// Possible values include:
+    /// - `"npm"`: npm workspaces
+    /// - `"yarn"`: Yarn workspaces
+    /// - `"pnpm"`: pnpm workspaces
+    /// - `"bun"`: Bun workspaces
+    /// - `"deno"`: Deno workspaces
+    /// - `"custom"`: Custom workspace configuration
+    #[napi(ts_type = "string | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub monorepo_type: Option<String>,
+}
+
+/// Package manager information.
+///
+/// Contains details about the detected package manager being used
+/// in the workspace, including the lock file name.
+///
+/// # Fields
+///
+/// - `name`: The package manager name
+/// - `lock_file`: The name of the lock file used
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface PackageManagerInfo {
+///   /** Package manager name (npm, yarn, pnpm, bun, jsr, unknown) */
+///   name: string;
+///   /** Lock file name */
+///   lockFile: string;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// // pnpm package manager
+/// const pnpm: PackageManagerInfo = {
+///   name: 'pnpm',
+///   lockFile: 'pnpm-lock.yaml'
+/// };
+///
+/// // npm package manager
+/// const npm: PackageManagerInfo = {
+///   name: 'npm',
+///   lockFile: 'package-lock.json'
+/// };
+/// ```
+// Allow dead_code until Story 3.2 implements the status command
+#[allow(dead_code)]
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageManagerInfo {
+    /// Package manager name.
+    ///
+    /// Possible values:
+    /// - `"npm"`: Node Package Manager
+    /// - `"yarn"`: Yarn package manager
+    /// - `"pnpm"`: pnpm package manager
+    /// - `"bun"`: Bun package manager
+    /// - `"jsr"`: JSR package manager
+    /// - `"unknown"`: Unable to detect package manager
+    pub name: String,
+
+    /// Lock file name used by the package manager.
+    ///
+    /// Examples:
+    /// - `"package-lock.json"` for npm
+    /// - `"yarn.lock"` for Yarn
+    /// - `"pnpm-lock.yaml"` for pnpm
+    /// - `"bun.lockb"` for Bun
+    pub lock_file: String,
+}
+
+/// Git branch information.
+///
+/// Contains the name of the current Git branch, if available.
+/// This information is useful for determining the context of
+/// pending changesets and version bumps.
+///
+/// # Fields
+///
+/// - `name`: The branch name
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface BranchInfo {
+///   /** Branch name */
+///   name: string;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// const branch: BranchInfo = { name: 'main' };
+/// const feature: BranchInfo = { name: 'feature/add-new-api' };
+/// ```
+// Allow dead_code until Story 3.2 implements the status command
+#[allow(dead_code)]
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct BranchInfo {
+    /// Git branch name.
+    ///
+    /// This is the name of the currently checked-out branch.
+    /// It does not include the `refs/heads/` prefix.
+    pub name: String,
+}
+
+/// Changeset information.
+///
+/// Represents a pending changeset that has been created but not yet
+/// consumed by a version bump operation. Each changeset is identified
+/// by a unique ID derived from the branch name.
+///
+/// # Fields
+///
+/// - `id`: The unique changeset identifier
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface ChangesetInfo {
+///   /** Changeset ID (derived from branch name) */
+///   id: string;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// const changeset: ChangesetInfo = { id: 'feature-add-login' };
+/// const fix: ChangesetInfo = { id: 'fix-memory-leak' };
+/// ```
+// Allow dead_code until Story 3.2 implements the status command
+#[allow(dead_code)]
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct ChangesetInfo {
+    /// Changeset unique identifier.
+    ///
+    /// This ID is typically derived from the Git branch name that
+    /// created the changeset. It uniquely identifies the changeset
+    /// within the workspace.
+    pub id: String,
+}
+
+/// Package information.
+///
+/// Contains metadata about a single package within the workspace,
+/// including its name, version, and relative path.
+///
+/// # Fields
+///
+/// - `name`: The package name (may include scope)
+/// - `version`: The current package version
+/// - `path`: The package path relative to workspace root
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface PackageInfo {
+///   /** Package name (may include scope like @org/package) */
+///   name: string;
+///   /** Package version (semver) */
+///   version: string;
+///   /** Package path relative to workspace root */
+///   path: string;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// // Scoped package
+/// const pkg: PackageInfo = {
+///   name: '@websublime/core',
+///   version: '1.2.3',
+///   path: 'packages/core'
+/// };
+///
+/// // Unscoped package
+/// const utils: PackageInfo = {
+///   name: 'utils',
+///   version: '0.1.0',
+///   path: 'packages/utils'
+/// };
+/// ```
+// Allow dead_code until Story 3.2 implements the status command
+#[allow(dead_code)]
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageInfo {
+    /// Package name.
+    ///
+    /// This is the name as defined in the package's `package.json`.
+    /// It may include a scope prefix (e.g., `@organization/package-name`).
+    pub name: String,
+
+    /// Package version.
+    ///
+    /// The current version of the package as defined in its `package.json`.
+    /// Follows semantic versioning format (e.g., `1.2.3`, `0.1.0-beta.1`).
+    pub version: String,
+
+    /// Package path relative to workspace root.
+    ///
+    /// This is the directory path where the package is located,
+    /// relative to the workspace root directory.
+    /// For simple repositories, this is typically `"."`.
+    pub path: String,
+}
+
+/// Status command response data.
+///
+/// This is the main response structure returned by the status command,
+/// containing comprehensive information about the workspace state.
+///
+/// # Fields
+///
+/// - `repository`: Repository type information
+/// - `package_manager`: Package manager details
+/// - `branch`: Current Git branch (if available)
+/// - `changesets`: List of pending changesets
+/// - `packages`: List of workspace packages
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface StatusData {
+///   /** Repository information */
+///   repository: RepositoryInfo;
+///   /** Package manager information */
+///   packageManager: PackageManagerInfo;
+///   /** Current branch (if available) */
+///   branch?: BranchInfo;
+///   /** Pending changesets */
+///   changesets: ChangesetInfo[];
+///   /** Workspace packages */
+///   packages: PackageInfo[];
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// const status: StatusData = {
+///   repository: { kind: 'monorepo', monorepoType: 'pnpm' },
+///   packageManager: { name: 'pnpm', lockFile: 'pnpm-lock.yaml' },
+///   branch: { name: 'main' },
+///   changesets: [{ id: 'feature-login' }],
+///   packages: [
+///     { name: '@org/core', version: '1.0.0', path: 'packages/core' },
+///     { name: '@org/utils', version: '0.5.0', path: 'packages/utils' }
+///   ]
+/// };
+/// ```
+// Allow dead_code until Story 3.2 implements the status command
+#[allow(dead_code)]
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct StatusData {
+    /// Repository type information.
+    ///
+    /// Contains details about whether this is a simple repository
+    /// or a monorepo, and if monorepo, which type.
+    pub repository: RepositoryInfo,
+
+    /// Package manager information.
+    ///
+    /// Details about the detected package manager and its lock file.
+    pub package_manager: PackageManagerInfo,
+
+    /// Current Git branch information.
+    ///
+    /// This field is `None` if:
+    /// - Git is not available
+    /// - The directory is not a Git repository
+    /// - Git is in a detached HEAD state
+    #[napi(ts_type = "BranchInfo | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<BranchInfo>,
+
+    /// List of pending changesets.
+    ///
+    /// These are changesets that have been created but not yet
+    /// consumed by a version bump operation.
+    pub changesets: Vec<ChangesetInfo>,
+
+    /// List of workspace packages.
+    ///
+    /// For simple repositories, this contains a single package.
+    /// For monorepos, this contains all packages in the workspace.
+    pub packages: Vec<PackageInfo>,
+}
+
+// ============================================================================
+// Constructors and Helper Methods
+// ============================================================================
+
+#[allow(dead_code)]
+impl StatusParams {
+    /// Creates a new `StatusParams` instance with the given root path.
+    ///
+    /// This is a convenience constructor for creating params with only
+    /// the required `root` field, leaving `config_path` as `None`.
+    ///
+    /// # Arguments
+    ///
+    /// * `root` - The workspace root directory path
+    ///
+    /// # Returns
+    ///
+    /// A new `StatusParams` instance with the specified root and no config path.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::status::StatusParams;
+    ///
+    /// let params = StatusParams::new("/path/to/workspace");
+    /// assert_eq!(params.root, "/path/to/workspace");
+    /// assert!(params.config_path.is_none());
+    /// ```
+    #[must_use]
+    pub fn new(root: impl Into<String>) -> Self {
+        Self { root: root.into(), config_path: None }
+    }
+
+    /// Creates a new `StatusParams` instance with root and config path.
+    ///
+    /// # Arguments
+    ///
+    /// * `root` - The workspace root directory path
+    /// * `config_path` - The custom configuration file path
+    ///
+    /// # Returns
+    ///
+    /// A new `StatusParams` instance with both root and config path set.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::status::StatusParams;
+    ///
+    /// let params = StatusParams::with_config(
+    ///     "/path/to/workspace",
+    ///     "/path/to/config.json"
+    /// );
+    /// assert_eq!(params.root, "/path/to/workspace");
+    /// assert_eq!(params.config_path, Some("/path/to/config.json".to_string()));
+    /// ```
+    #[must_use]
+    pub fn with_config(root: impl Into<String>, config_path: impl Into<String>) -> Self {
+        Self { root: root.into(), config_path: Some(config_path.into()) }
+    }
+}
+
+#[allow(dead_code)]
+impl RepositoryInfo {
+    /// Creates a new `RepositoryInfo` for a simple (single package) repository.
+    ///
+    /// # Returns
+    ///
+    /// A new `RepositoryInfo` with `kind` set to `"simple"` and no monorepo type.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::status::RepositoryInfo;
+    ///
+    /// let info = RepositoryInfo::simple();
+    /// assert_eq!(info.kind, "simple");
+    /// assert!(info.monorepo_type.is_none());
+    /// ```
+    #[must_use]
+    pub fn simple() -> Self {
+        Self { kind: "simple".to_string(), monorepo_type: None }
+    }
+
+    /// Creates a new `RepositoryInfo` for a monorepo.
+    ///
+    /// # Arguments
+    ///
+    /// * `monorepo_type` - The type of monorepo (e.g., "pnpm", "npm", "yarn")
+    ///
+    /// # Returns
+    ///
+    /// A new `RepositoryInfo` with `kind` set to `"monorepo"` and the specified type.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::status::RepositoryInfo;
+    ///
+    /// let info = RepositoryInfo::monorepo("pnpm");
+    /// assert_eq!(info.kind, "monorepo");
+    /// assert_eq!(info.monorepo_type, Some("pnpm".to_string()));
+    /// ```
+    #[must_use]
+    pub fn monorepo(monorepo_type: impl Into<String>) -> Self {
+        Self { kind: "monorepo".to_string(), monorepo_type: Some(monorepo_type.into()) }
+    }
+
+    /// Creates a new `RepositoryInfo` for an unknown repository type.
+    ///
+    /// # Returns
+    ///
+    /// A new `RepositoryInfo` with `kind` set to `"unknown"` and no monorepo type.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::status::RepositoryInfo;
+    ///
+    /// let info = RepositoryInfo::unknown();
+    /// assert_eq!(info.kind, "unknown");
+    /// assert!(info.monorepo_type.is_none());
+    /// ```
+    #[must_use]
+    pub fn unknown() -> Self {
+        Self { kind: "unknown".to_string(), monorepo_type: None }
+    }
+
+    /// Checks if this repository is a simple (single package) repository.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the repository kind is `"simple"`, `false` otherwise.
+    #[must_use]
+    pub fn is_simple(&self) -> bool {
+        self.kind == "simple"
+    }
+
+    /// Checks if this repository is a monorepo.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the repository kind is `"monorepo"`, `false` otherwise.
+    #[must_use]
+    pub fn is_monorepo(&self) -> bool {
+        self.kind == "monorepo"
+    }
+}
+
+#[allow(dead_code)]
+impl PackageManagerInfo {
+    /// Creates a new `PackageManagerInfo` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The package manager name
+    /// * `lock_file` - The lock file name
+    ///
+    /// # Returns
+    ///
+    /// A new `PackageManagerInfo` instance with the specified values.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::status::PackageManagerInfo;
+    ///
+    /// let info = PackageManagerInfo::new("pnpm", "pnpm-lock.yaml");
+    /// assert_eq!(info.name, "pnpm");
+    /// assert_eq!(info.lock_file, "pnpm-lock.yaml");
+    /// ```
+    #[must_use]
+    pub fn new(name: impl Into<String>, lock_file: impl Into<String>) -> Self {
+        Self { name: name.into(), lock_file: lock_file.into() }
+    }
+
+    /// Creates a `PackageManagerInfo` for npm.
+    #[must_use]
+    pub fn npm() -> Self {
+        Self::new("npm", "package-lock.json")
+    }
+
+    /// Creates a `PackageManagerInfo` for yarn.
+    #[must_use]
+    pub fn yarn() -> Self {
+        Self::new("yarn", "yarn.lock")
+    }
+
+    /// Creates a `PackageManagerInfo` for pnpm.
+    #[must_use]
+    pub fn pnpm() -> Self {
+        Self::new("pnpm", "pnpm-lock.yaml")
+    }
+
+    /// Creates a `PackageManagerInfo` for bun.
+    #[must_use]
+    pub fn bun() -> Self {
+        Self::new("bun", "bun.lockb")
+    }
+
+    /// Creates a `PackageManagerInfo` for an unknown package manager.
+    #[must_use]
+    pub fn unknown() -> Self {
+        Self::new("unknown", "")
+    }
+}
+
+#[allow(dead_code)]
+impl BranchInfo {
+    /// Creates a new `BranchInfo` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The branch name
+    ///
+    /// # Returns
+    ///
+    /// A new `BranchInfo` instance with the specified name.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::status::BranchInfo;
+    ///
+    /// let branch = BranchInfo::new("main");
+    /// assert_eq!(branch.name, "main");
+    /// ```
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+#[allow(dead_code)]
+impl ChangesetInfo {
+    /// Creates a new `ChangesetInfo` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - The changeset identifier
+    ///
+    /// # Returns
+    ///
+    /// A new `ChangesetInfo` instance with the specified ID.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::status::ChangesetInfo;
+    ///
+    /// let changeset = ChangesetInfo::new("feature-login");
+    /// assert_eq!(changeset.id, "feature-login");
+    /// ```
+    #[must_use]
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into() }
+    }
+}
+
+#[allow(dead_code)]
+impl PackageInfo {
+    /// Creates a new `PackageInfo` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The package name (may include scope)
+    /// * `version` - The package version
+    /// * `path` - The package path relative to workspace root
+    ///
+    /// # Returns
+    ///
+    /// A new `PackageInfo` instance with the specified values.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::status::PackageInfo;
+    ///
+    /// let pkg = PackageInfo::new("@org/core", "1.2.3", "packages/core");
+    /// assert_eq!(pkg.name, "@org/core");
+    /// assert_eq!(pkg.version, "1.2.3");
+    /// assert_eq!(pkg.path, "packages/core");
+    /// ```
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        version: impl Into<String>,
+        path: impl Into<String>,
+    ) -> Self {
+        Self { name: name.into(), version: version.into(), path: path.into() }
+    }
+}
+
+#[allow(dead_code)]
+impl StatusData {
+    /// Creates a new `StatusData` builder for constructing status responses.
+    ///
+    /// This method provides a convenient way to create `StatusData` with
+    /// sensible defaults and a fluent builder pattern.
+    ///
+    /// # Arguments
+    ///
+    /// * `repository` - Repository type information
+    /// * `package_manager` - Package manager information
+    ///
+    /// # Returns
+    ///
+    /// A new `StatusData` instance with empty changesets and packages.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::status::{StatusData, RepositoryInfo, PackageManagerInfo};
+    ///
+    /// let data = StatusData::new(
+    ///     RepositoryInfo::simple(),
+    ///     PackageManagerInfo::pnpm(),
+    /// );
+    /// assert!(data.changesets.is_empty());
+    /// assert!(data.packages.is_empty());
+    /// ```
+    #[must_use]
+    pub fn new(repository: RepositoryInfo, package_manager: PackageManagerInfo) -> Self {
+        Self {
+            repository,
+            package_manager,
+            branch: None,
+            changesets: Vec::new(),
+            packages: Vec::new(),
+        }
+    }
+
+    /// Sets the branch information.
+    ///
+    /// # Arguments
+    ///
+    /// * `branch` - The branch information to set
+    ///
+    /// # Returns
+    ///
+    /// The modified `StatusData` instance for method chaining.
+    #[must_use]
+    pub fn with_branch(mut self, branch: BranchInfo) -> Self {
+        self.branch = Some(branch);
+        self
+    }
+
+    /// Sets the changesets list.
+    ///
+    /// # Arguments
+    ///
+    /// * `changesets` - The list of changesets
+    ///
+    /// # Returns
+    ///
+    /// The modified `StatusData` instance for method chaining.
+    #[must_use]
+    pub fn with_changesets(mut self, changesets: Vec<ChangesetInfo>) -> Self {
+        self.changesets = changesets;
+        self
+    }
+
+    /// Sets the packages list.
+    ///
+    /// # Arguments
+    ///
+    /// * `packages` - The list of packages
+    ///
+    /// # Returns
+    ///
+    /// The modified `StatusData` instance for method chaining.
+    #[must_use]
+    pub fn with_packages(mut self, packages: Vec<PackageInfo>) -> Self {
+        self.packages = packages;
+        self
+    }
+}


### PR DESCRIPTION
Implement all NAPI-compatible type definitions for the status command as specified in Story 3.1 of the Node.js bindings development plan.

Types implemented:
- StatusParams: input parameters with root and optional configPath
- RepositoryInfo: repository type (simple/monorepo) with optional monorepoType
- PackageManagerInfo: package manager name and lock file
- BranchInfo: current Git branch name
- ChangesetInfo: pending changeset identifier
- PackageInfo: package name, version, and path
- StatusData: main response structure combining all status information

Features:
- All types use #[napi(object)] for JavaScript object exposure
- Optional fields use proper TypeScript typing (string | undefined)
- Serde serialization skips None values for cleaner JSON output
- Builder pattern for StatusData with fluent API
- Constructor methods for all types with sensible defaults

Testing:
- Added 45 comprehensive unit tests for status types
- Tests cover constructors, clone, debug, serialization
- Integration-style tests for complete status responses

Documentation:
- Module-level docs with What/How/Why structure
- TypeScript and Rust usage examples
- Detailed field documentation for all types