### PR TITLE
feat(WOR-TSK-184): implement changesetUpdate NAPI function

### DIFF
--- a/crates/node/Cargo.lock
+++ b/crates/node/Cargo.lock
@@ -2067,7 +2067,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sublime_cli_tools"
-version = "0.0.27"
+version = "0.0.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "sublime_pkg_tools"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "sublime_standard_tools"
-version = "0.0.14"
+version = "0.0.15"
 dependencies = [
  "async-trait",
  "glob",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -69,10 +69,10 @@ napi = { version = "3.6.0", features = ["async", "tokio_rt", "napi9", "serde-jso
 napi-derive = "3.4.0"
 
 # Workspace crates - using path dependencies
-sublime_cli_tools = { version = "0.0.27", path = "../cli" }
+sublime_cli_tools = { version = "0.0.28", path = "../cli" }
 sublime_git_tools = { version = "0.0.15", path = "../git" }
-sublime_pkg_tools = { version = "0.0.19", path = "../pkg" }
-sublime_standard_tools = { version = "0.0.14", path = "../standard" }
+sublime_pkg_tools = { version = "0.0.20", path = "../pkg" }
+sublime_standard_tools = { version = "0.0.15", path = "../standard" }
 
 # Serialization
 serde = { version = "1.0.203", features = ["derive"] }

--- a/crates/node/src/commands/changeset.rs
+++ b/crates/node/src/commands/changeset.rs
@@ -11,6 +11,7 @@
 //! The module provides the following functions:
 //!
 //! - `changeset_add`: Creates a new changeset for the current branch
+//! - `changeset_update`: Updates an existing changeset with new packages, commits, bump type, or environments
 //!
 //! Each function follows this pattern:
 //! 1. Validates the input parameters
@@ -38,7 +39,7 @@
 //! # Examples
 //!
 //! ```typescript
-//! import { changesetAdd } from '@websublime/workspace-tools';
+//! import { changesetAdd, changesetUpdate } from '@websublime/workspace-tools';
 //!
 //! // Add a new changeset
 //! const addResult = await changesetAdd({
@@ -55,6 +56,22 @@
 //! } else {
 //!   console.error(`Error [${addResult.error.code}]: ${addResult.error.message}`);
 //! }
+//!
+//! // Update an existing changeset
+//! const updateResult = await changesetUpdate({
+//!   root: '.',
+//!   id: 'feature/new-api',
+//!   packages: ['@scope/new-package'],
+//!   bump: 'major'
+//! });
+//!
+//! if (updateResult.success) {
+//!   console.log(`Updated: ${updateResult.data.updated}`);
+//!   console.log(`Packages added: ${updateResult.data.summary.packagesAdded}`);
+//!   console.log(`Current packages: ${updateResult.data.changeset.packages.join(', ')}`);
+//! } else {
+//!   console.error(`Error [${updateResult.error.code}]: ${updateResult.error.message}`);
+//! }
 //! ```
 
 use std::io::Write;
@@ -65,11 +82,14 @@ use napi_derive::napi;
 use serde::Deserialize;
 
 use crate::error::ErrorInfo;
-use crate::types::changeset::{ChangesetAddApiResponse, ChangesetAddData, ChangesetAddParams};
+use crate::types::changeset::{
+    ChangesetAddApiResponse, ChangesetAddData, ChangesetAddParams, ChangesetDetailInfo,
+    ChangesetUpdateApiResponse, ChangesetUpdateData, ChangesetUpdateParams, UpdateSummaryInfo,
+};
 use crate::validation::validators;
 
-use sublime_cli_tools::cli::commands::ChangesetCreateArgs;
-use sublime_cli_tools::commands::changeset::execute_add;
+use sublime_cli_tools::cli::commands::{ChangesetCreateArgs, ChangesetUpdateArgs};
+use sublime_cli_tools::commands::changeset::{execute_add, execute_update};
 use sublime_cli_tools::output::{Output, OutputFormat};
 
 // ============================================================================
@@ -462,6 +482,404 @@ pub async fn changeset_add(params: ChangesetAddParams) -> ChangesetAddApiRespons
         Ok(Ok(data)) => ChangesetAddApiResponse::success(data),
         Ok(Err(error)) => ChangesetAddApiResponse::failure(error),
         Err(join_error) => ChangesetAddApiResponse::failure(ErrorInfo::execution(format!(
+            "Task execution failed: {join_error}"
+        ))),
+    }
+}
+
+// ============================================================================
+// Changeset Update - CLI Response Types
+// ============================================================================
+
+/// CLI JSON response data for changeset update command.
+///
+/// This type mirrors the `ChangesetUpdateResponse` structure from the CLI's
+/// update command, used for deserializing the captured JSON output.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliChangesetUpdateResponseData {
+    /// Whether the operation succeeded.
+    #[allow(dead_code)]
+    pub(crate) success: bool,
+    /// Summary of what was updated.
+    pub(crate) updated: CliUpdateSummary,
+    /// The updated changeset details.
+    pub(crate) changeset: CliUpdatedChangesetInfo,
+}
+
+/// CLI update summary structure.
+///
+/// Mirrors the `UpdateSummary` structure from the CLI's changeset update command.
+/// Field names use snake_case to match the JSON output format.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliUpdateSummary {
+    /// Number of packages added.
+    pub(crate) packages_added: usize,
+    /// Number of commits added.
+    pub(crate) commits_added: usize,
+    /// Whether bump type was changed.
+    pub(crate) bump_updated: bool,
+    /// Number of environments added.
+    pub(crate) environments_added: usize,
+}
+
+/// CLI changeset information structure for update response.
+///
+/// Mirrors the `ChangesetInfo` structure from the CLI's update command.
+/// Field names use camelCase to match the JSON output format.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliUpdatedChangesetInfo {
+    /// Branch name (also serves as unique identifier).
+    pub(crate) branch: String,
+    /// Version bump type (major, minor, patch, none).
+    pub(crate) bump: String,
+    /// List of affected packages.
+    pub(crate) packages: Vec<String>,
+    /// Target environments.
+    pub(crate) environments: Vec<String>,
+    /// List of commit IDs.
+    pub(crate) commits: Vec<String>,
+    /// Creation timestamp (RFC3339 format).
+    pub(crate) created_at: String,
+    /// Last update timestamp (RFC3339 format).
+    pub(crate) updated_at: String,
+}
+
+// ============================================================================
+// Changeset Update - Conversion Functions
+// ============================================================================
+
+/// Converts CLI update summary to NAPI-compatible `UpdateSummaryInfo`.
+///
+/// This function performs a field-by-field conversion from the CLI's
+/// internal types to the NAPI types exposed to JavaScript.
+///
+/// # Arguments
+///
+/// * `cli_summary` - The parsed CLI update summary
+///
+/// # Returns
+///
+/// An `UpdateSummaryInfo` instance suitable for returning to JavaScript.
+pub(crate) fn convert_to_napi_update_summary(cli_summary: &CliUpdateSummary) -> UpdateSummaryInfo {
+    // Safe truncation: these counts will never exceed u32::MAX in practice
+    #[allow(clippy::cast_possible_truncation)]
+    UpdateSummaryInfo {
+        packages_added: cli_summary.packages_added as u32,
+        commits_added: cli_summary.commits_added as u32,
+        bump_updated: cli_summary.bump_updated,
+        environments_added: cli_summary.environments_added as u32,
+    }
+}
+
+/// Converts CLI changeset info to NAPI-compatible `ChangesetDetailInfo`.
+///
+/// This function performs a field-by-field conversion from the CLI's
+/// internal types to the NAPI types exposed to JavaScript.
+///
+/// # Arguments
+///
+/// * `cli_info` - The parsed CLI changeset information
+///
+/// # Returns
+///
+/// A `ChangesetDetailInfo` instance suitable for returning to JavaScript.
+pub(crate) fn convert_to_napi_changeset_detail(
+    cli_info: &CliUpdatedChangesetInfo,
+) -> ChangesetDetailInfo {
+    ChangesetDetailInfo {
+        id: cli_info.branch.clone(),
+        branch: cli_info.branch.clone(),
+        bump: cli_info.bump.clone(),
+        packages: cli_info.packages.clone(),
+        environments: cli_info.environments.clone(),
+        commits: cli_info.commits.clone(),
+        message: None, // CLI update response doesn't include message
+        created_at: cli_info.created_at.clone(),
+        updated_at: cli_info.updated_at.clone(),
+    }
+}
+
+/// Converts CLI update response to NAPI-compatible `ChangesetUpdateData`.
+///
+/// # Arguments
+///
+/// * `cli_data` - The parsed CLI update response data
+///
+/// # Returns
+///
+/// A `ChangesetUpdateData` instance suitable for returning to JavaScript.
+pub(crate) fn convert_to_napi_update_data(
+    cli_data: &CliChangesetUpdateResponseData,
+) -> ChangesetUpdateData {
+    let summary = convert_to_napi_update_summary(&cli_data.updated);
+    let changeset = convert_to_napi_changeset_detail(&cli_data.changeset);
+    let updated = summary.has_changes();
+
+    ChangesetUpdateData { updated, summary, changeset }
+}
+
+/// Parses the JSON response from the CLI update command and converts it to NAPI types.
+///
+/// # Arguments
+///
+/// * `json_bytes` - The raw JSON bytes captured from CLI output
+///
+/// # Returns
+///
+/// * `Ok(ChangesetUpdateData)` - Successfully parsed and converted update data
+/// * `Err(ErrorInfo)` - Parsing failed or CLI returned an error
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The JSON is malformed or cannot be parsed
+/// - The CLI returned `success: false` with an error message
+/// - The CLI returned `success: true` but `data` is missing
+pub(crate) fn parse_changeset_update_response(
+    json_bytes: &[u8],
+) -> Result<ChangesetUpdateData, ErrorInfo> {
+    // Convert bytes to string first for better error messages
+    let json_str = std::str::from_utf8(json_bytes)
+        .map_err(|e| ErrorInfo::execution(format!("Invalid UTF-8 in CLI response: {e}")))?;
+
+    // Handle empty response
+    if json_str.trim().is_empty() {
+        return Err(ErrorInfo::execution("CLI returned empty response"));
+    }
+
+    // Parse the JSON response
+    let response: CliJsonResponse<CliChangesetUpdateResponseData> = serde_json::from_str(json_str)
+        .map_err(|e| {
+            ErrorInfo::execution(format!(
+                "Failed to parse CLI JSON response: {e} (length={})",
+                json_str.len()
+            ))
+        })?;
+
+    // Check for CLI-level errors
+    if !response.success {
+        let error_message = response.error.unwrap_or_else(|| "Unknown CLI error".to_string());
+        return Err(ErrorInfo::execution(error_message));
+    }
+
+    // Extract and convert data
+    let cli_data =
+        response.data.ok_or_else(|| ErrorInfo::execution("CLI returned success but no data"))?;
+
+    Ok(convert_to_napi_update_data(&cli_data))
+}
+
+// ============================================================================
+// Changeset Update - Parameter Validation
+// ============================================================================
+
+/// Validates changeset update command parameters.
+///
+/// Ensures the root path is valid and that required parameters are provided
+/// before executing the CLI command. For NAPI bindings, the `id` parameter
+/// is required since auto-detection from git branch is not reliable in
+/// programmatic contexts.
+///
+/// # Arguments
+///
+/// * `params` - The changeset update parameters to validate
+///
+/// # Returns
+///
+/// * `Ok(PathBuf)` - The validated root path
+/// * `Err(ErrorInfo)` - Validation failed
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The root path is empty, doesn't exist, or is not a directory
+/// - The `id` parameter is not provided
+/// - The bump type (if provided) is invalid
+pub(crate) fn validate_update_params(params: &ChangesetUpdateParams) -> Result<PathBuf, ErrorInfo> {
+    // Validate root path exists and is a directory
+    validators::root(&params.root)?;
+
+    // Validate id is required for NAPI (cannot auto-detect git branch reliably)
+    if params.id.is_none() {
+        return Err(ErrorInfo::validation(
+            "id is required for changesetUpdate. Provide the branch name or changeset ID.",
+            Some("id"),
+        ));
+    }
+
+    // Validate bump type if provided
+    if let Some(ref bump) = params.bump {
+        validators::bump_type_info(bump)?;
+    }
+
+    Ok(PathBuf::from(&params.root))
+}
+
+/// Converts NAPI parameters to CLI arguments.
+///
+/// This function transforms the NAPI-friendly `ChangesetUpdateParams` into the
+/// CLI's `ChangesetUpdateArgs` structure.
+///
+/// # Arguments
+///
+/// * `params` - The NAPI changeset update parameters
+///
+/// # Returns
+///
+/// A `ChangesetUpdateArgs` instance ready for CLI execution.
+pub(crate) fn convert_update_params_to_args(params: &ChangesetUpdateParams) -> ChangesetUpdateArgs {
+    ChangesetUpdateArgs {
+        id: params.id.clone(),
+        commit: params.commit.clone(),
+        packages: params.packages.clone(),
+        bump: params.bump.clone(),
+        env: params.environments.clone(),
+    }
+}
+
+// ============================================================================
+// Changeset Update - NAPI Function
+// ============================================================================
+
+/// Update an existing changeset in the workspace.
+///
+/// Modifies an existing changeset by adding packages, commits, environments,
+/// or changing the bump type. The changeset is identified by the `id` parameter,
+/// which corresponds to the branch name.
+///
+/// This function always operates in non-interactive mode. The `id` parameter
+/// is required since auto-detection of the current git branch is not reliable
+/// in programmatic contexts.
+///
+/// @param params - Changeset update parameters containing:
+///   - `root`: Workspace root directory path (required)
+///   - `configPath`: Optional custom config file path
+///   - `id`: Branch name or changeset ID (required)
+///   - `commit`: Optional commit hash to add
+///   - `packages`: Optional list of packages to add
+///   - `bump`: Optional new bump type (major, minor, patch)
+///   - `environments`: Optional list of environments to add
+///
+/// @returns `Promise<ChangesetUpdateApiResponse>` containing:
+///   - On success: `{ success: true, data: ChangesetUpdateData }`
+///   - On failure: `{ success: false, error: ErrorInfo }`
+///
+/// @example Add packages to an existing changeset
+/// ```typescript
+/// const result = await changesetUpdate({
+///   root: '/path/to/workspace',
+///   id: 'feature/new-api',
+///   packages: ['@scope/new-package']
+/// });
+///
+/// if (result.success) {
+///   console.log(`Updated: ${result.data.updated}`);
+///   console.log(`Packages added: ${result.data.summary.packagesAdded}`);
+/// }
+/// ```
+///
+/// @example Add a commit and change bump type
+/// ```typescript
+/// const result = await changesetUpdate({
+///   root: '/path/to/workspace',
+///   id: 'feature/breaking-change',
+///   commit: 'abc123def456',
+///   bump: 'major'
+/// });
+///
+/// if (result.success) {
+///   console.log(`Bump updated: ${result.data.summary.bumpUpdated}`);
+///   console.log(`Current bump: ${result.data.changeset.bump}`);
+/// }
+/// ```
+///
+/// @example Add environments
+/// ```typescript
+/// const result = await changesetUpdate({
+///   root: '/path/to/workspace',
+///   id: 'feature/deploy',
+///   environments: ['staging', 'production']
+/// });
+/// ```
+///
+/// @example Error handling
+/// ```typescript
+/// const result = await changesetUpdate({
+///   root: '/path/to/workspace',
+///   id: 'nonexistent-branch'
+/// });
+///
+/// if (!result.success) {
+///   switch (result.error.code) {
+///     case 'ENOENT':
+///       console.error('Path or changeset not found');
+///       break;
+///     case 'EVALIDATION':
+///       console.error('Invalid parameters:', result.error.message);
+///       break;
+///     case 'EEXECUTION':
+///       console.error('Update failed:', result.error.message);
+///       break;
+///     default:
+///       console.error(`Error: ${result.error.message}`);
+///   }
+/// }
+/// ```
+#[napi(js_name = "changesetUpdate")]
+pub async fn changeset_update(params: ChangesetUpdateParams) -> ChangesetUpdateApiResponse {
+    // 1. Validate parameters (synchronous validation before spawning)
+    let root_path = match validate_update_params(&params) {
+        Ok(path) => path,
+        Err(error) => return ChangesetUpdateApiResponse::failure(error),
+    };
+
+    // 2. Prepare config path
+    let config_path: Option<PathBuf> = params.config_path.as_ref().map(PathBuf::from);
+
+    // 3. Convert NAPI params to CLI args
+    let args = convert_update_params_to_args(&params);
+
+    // 4. Execute CLI command in a blocking task
+    // The CLI's execute_update uses types that are not Send/Sync (RefCell, git2::Repository),
+    // so we must run it on a blocking thread via spawn_blocking.
+    let result = tokio::task::spawn_blocking(move || {
+        // Create a new tokio runtime for the blocking context
+        // This is necessary because execute_update is async but we're in a blocking context
+        let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                return Err(ErrorInfo::execution(format!("Failed to create runtime: {e}")));
+            }
+        };
+
+        rt.block_on(async {
+            // Create shared buffer for output capture
+            let buffer = SharedBuffer::new();
+
+            // Create Output with JSON format
+            let output = Output::new(OutputFormat::Json, buffer.clone(), true);
+
+            // Execute the CLI command
+            if let Err(cli_error) =
+                execute_update(&args, &output, Some(root_path.as_path()), config_path.as_deref())
+                    .await
+            {
+                return Err(ErrorInfo::from(cli_error));
+            }
+
+            // Extract and parse JSON
+            let json_bytes = buffer.take_bytes();
+            parse_changeset_update_response(&json_bytes)
+        })
+    })
+    .await;
+
+    // 5. Handle spawn_blocking result
+    match result {
+        Ok(Ok(data)) => ChangesetUpdateApiResponse::success(data),
+        Ok(Err(error)) => ChangesetUpdateApiResponse::failure(error),
+        Err(join_error) => ChangesetUpdateApiResponse::failure(ErrorInfo::execution(format!(
             "Task execution failed: {join_error}"
         ))),
     }

--- a/crates/node/src/commands/mod.rs
+++ b/crates/node/src/commands/mod.rs
@@ -68,7 +68,8 @@ pub(crate) mod changeset;
 // Re-export changeset functions for lib.rs
 // Story 4.2: changesetAdd
 pub use changeset::changeset_add;
-// TODO: will be implemented on story 4.3 (changesetUpdate)
+// Story 4.3: changesetUpdate
+pub use changeset::changeset_update;
 // TODO: will be implemented on story 4.4 (changesetList)
 // TODO: will be implemented on story 4.5 (changesetShow)
 // TODO: will be implemented on story 4.6 (changesetRemove)

--- a/crates/node/src/commands/tests.rs
+++ b/crates/node/src/commands/tests.rs
@@ -1446,3 +1446,456 @@ mod changeset_add_tests {
         }
     }
 }
+
+// =============================================================================
+// Changeset Update Tests (Story 4.3)
+// =============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod changeset_update_tests {
+    use std::io::Write;
+
+    use crate::commands::changeset::{
+        CliUpdateSummary, CliUpdatedChangesetInfo, SharedBuffer, convert_to_napi_changeset_detail,
+        convert_to_napi_update_summary, convert_update_params_to_args,
+        parse_changeset_update_response, validate_update_params,
+    };
+    use crate::types::changeset::ChangesetUpdateParams;
+
+    // -------------------------------------------------------------------------
+    // SharedBuffer Tests (Reused from changeset_add, but included for completeness)
+    // -------------------------------------------------------------------------
+
+    mod shared_buffer_tests {
+        use super::*;
+
+        #[test]
+        fn test_shared_buffer_new() {
+            let buffer = SharedBuffer::new();
+            assert!(buffer.take_bytes().is_empty());
+        }
+
+        #[test]
+        fn test_shared_buffer_write() {
+            let mut buffer = SharedBuffer::new();
+            let written = buffer.write(b"hello").unwrap();
+            assert_eq!(written, 5);
+            assert_eq!(buffer.take_bytes(), b"hello");
+        }
+
+        #[test]
+        fn test_shared_buffer_multiple_writes() {
+            let mut buffer = SharedBuffer::new();
+            let _ = buffer.write(b"hello ");
+            let _ = buffer.write(b"world");
+            assert_eq!(buffer.take_bytes(), b"hello world");
+        }
+
+        #[test]
+        fn test_shared_buffer_clone_shares_data() {
+            let mut buffer = SharedBuffer::new();
+            let buffer_clone = buffer.clone();
+
+            let _ = buffer.write(b"test data");
+
+            // Both should see the same data
+            assert_eq!(buffer.take_bytes(), b"test data");
+            assert_eq!(buffer_clone.take_bytes(), b"test data");
+        }
+
+        #[test]
+        fn test_shared_buffer_flush() {
+            let mut buffer = SharedBuffer::new();
+            // Flush should always succeed (no-op for Vec)
+            assert!(buffer.flush().is_ok());
+        }
+
+        #[test]
+        fn test_shared_buffer_take_bytes_preserves_data() {
+            let mut buffer = SharedBuffer::new();
+            let _ = buffer.write(b"preserved");
+
+            // take_bytes clones, so data is preserved
+            let first_take = buffer.take_bytes();
+            let second_take = buffer.take_bytes();
+            assert_eq!(first_take, second_take);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Parse Response Tests
+    // -------------------------------------------------------------------------
+
+    mod parse_response_tests {
+        use super::*;
+
+        #[test]
+        fn test_parse_changeset_update_response_success() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "success": true,
+                    "updated": {
+                        "packages_added": 2,
+                        "commits_added": 1,
+                        "bump_updated": true,
+                        "environments_added": 1
+                    },
+                    "changeset": {
+                        "branch": "feature/new-api",
+                        "bump": "major",
+                        "packages": ["@scope/core", "@scope/utils", "@scope/new-pkg"],
+                        "environments": ["staging", "production"],
+                        "commits": ["abc123", "def456", "ghi789"],
+                        "createdAt": "2025-01-20T10:00:00Z",
+                        "updatedAt": "2025-01-20T12:00:00Z"
+                    }
+                }
+            }"#;
+
+            let result = parse_changeset_update_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            assert!(data.updated);
+            assert_eq!(data.summary.packages_added, 2);
+            assert_eq!(data.summary.commits_added, 1);
+            assert!(data.summary.bump_updated);
+            assert_eq!(data.summary.environments_added, 1);
+            assert_eq!(data.changeset.branch, "feature/new-api");
+            assert_eq!(data.changeset.bump, "major");
+            assert_eq!(data.changeset.packages.len(), 3);
+        }
+
+        #[test]
+        fn test_parse_changeset_update_response_no_changes() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "success": true,
+                    "updated": {
+                        "packages_added": 0,
+                        "commits_added": 0,
+                        "bump_updated": false,
+                        "environments_added": 0
+                    },
+                    "changeset": {
+                        "branch": "main",
+                        "bump": "patch",
+                        "packages": ["my-package"],
+                        "environments": [],
+                        "commits": [],
+                        "createdAt": "2025-01-20T10:00:00Z",
+                        "updatedAt": "2025-01-20T10:00:00Z"
+                    }
+                }
+            }"#;
+
+            let result = parse_changeset_update_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            // When no changes were made, updated should be false
+            assert!(!data.updated);
+            assert_eq!(data.summary.packages_added, 0);
+            assert!(!data.summary.bump_updated);
+        }
+
+        #[test]
+        fn test_parse_changeset_update_response_cli_error() {
+            let json = r#"{
+                "success": false,
+                "error": "No changeset found for branch 'nonexistent'"
+            }"#;
+
+            let result = parse_changeset_update_response(json.as_bytes());
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert!(error.message.contains("No changeset found"));
+        }
+
+        #[test]
+        fn test_parse_changeset_update_response_empty() {
+            let result = parse_changeset_update_response(b"");
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert!(error.message.contains("empty response"));
+        }
+
+        #[test]
+        fn test_parse_changeset_update_response_whitespace_only() {
+            let result = parse_changeset_update_response(b"   \n\t  ");
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert!(error.message.contains("empty response"));
+        }
+
+        #[test]
+        fn test_parse_changeset_update_response_invalid_json() {
+            let result = parse_changeset_update_response(b"not valid json");
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Failed to parse"));
+        }
+
+        #[test]
+        fn test_parse_changeset_update_response_invalid_utf8() {
+            let invalid_utf8 = vec![0xff, 0xfe, 0x00, 0x01];
+            let result = parse_changeset_update_response(&invalid_utf8);
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Invalid UTF-8"));
+        }
+
+        #[test]
+        fn test_parse_changeset_update_response_success_no_data() {
+            let json = r#"{"success": true}"#;
+            let result = parse_changeset_update_response(json.as_bytes());
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert!(error.message.contains("success but no data"));
+        }
+
+        #[test]
+        fn test_parse_changeset_update_response_cli_error_no_message() {
+            let json = r#"{"success": false}"#;
+            let result = parse_changeset_update_response(json.as_bytes());
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Unknown CLI error"));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Conversion Tests
+    // -------------------------------------------------------------------------
+
+    mod conversion_tests {
+        use super::*;
+
+        #[test]
+        fn test_convert_to_napi_update_summary() {
+            let cli_summary = CliUpdateSummary {
+                packages_added: 3,
+                commits_added: 1,
+                bump_updated: true,
+                environments_added: 2,
+            };
+
+            let summary = convert_to_napi_update_summary(&cli_summary);
+
+            assert_eq!(summary.packages_added, 3);
+            assert_eq!(summary.commits_added, 1);
+            assert!(summary.bump_updated);
+            assert_eq!(summary.environments_added, 2);
+            assert!(summary.has_changes());
+        }
+
+        #[test]
+        fn test_convert_to_napi_update_summary_no_changes() {
+            let cli_summary = CliUpdateSummary {
+                packages_added: 0,
+                commits_added: 0,
+                bump_updated: false,
+                environments_added: 0,
+            };
+
+            let summary = convert_to_napi_update_summary(&cli_summary);
+
+            assert_eq!(summary.packages_added, 0);
+            assert_eq!(summary.commits_added, 0);
+            assert!(!summary.bump_updated);
+            assert_eq!(summary.environments_added, 0);
+            assert!(!summary.has_changes());
+        }
+
+        #[test]
+        fn test_convert_to_napi_changeset_detail() {
+            let cli_info = CliUpdatedChangesetInfo {
+                branch: "feature/test".to_string(),
+                bump: "minor".to_string(),
+                packages: vec!["pkg-a".to_string(), "pkg-b".to_string()],
+                environments: vec!["production".to_string()],
+                commits: vec!["commit1".to_string(), "commit2".to_string()],
+                created_at: "2025-01-20T10:00:00Z".to_string(),
+                updated_at: "2025-01-20T12:00:00Z".to_string(),
+            };
+
+            let detail = convert_to_napi_changeset_detail(&cli_info);
+
+            assert_eq!(detail.id, "feature/test");
+            assert_eq!(detail.branch, "feature/test");
+            assert_eq!(detail.bump, "minor");
+            assert_eq!(detail.packages, vec!["pkg-a", "pkg-b"]);
+            assert_eq!(detail.environments, vec!["production"]);
+            assert_eq!(detail.commits, vec!["commit1", "commit2"]);
+            assert!(detail.message.is_none());
+            assert_eq!(detail.created_at, "2025-01-20T10:00:00Z");
+            assert_eq!(detail.updated_at, "2025-01-20T12:00:00Z");
+        }
+
+        #[test]
+        fn test_convert_update_params_to_args_defaults() {
+            let params = ChangesetUpdateParams::new(".").with_id("feature/test");
+
+            let args = convert_update_params_to_args(&params);
+
+            assert_eq!(args.id, Some("feature/test".to_string()));
+            assert!(args.commit.is_none());
+            assert!(args.packages.is_none());
+            assert!(args.bump.is_none());
+            assert!(args.env.is_none());
+        }
+
+        #[test]
+        fn test_convert_update_params_to_args_full() {
+            let params = ChangesetUpdateParams::new(".")
+                .with_id("feature/test")
+                .with_commit("abc123")
+                .with_packages(vec!["pkg-a".to_string(), "pkg-b".to_string()])
+                .with_bump("major")
+                .with_environments(vec!["staging".to_string()]);
+
+            let args = convert_update_params_to_args(&params);
+
+            assert_eq!(args.id, Some("feature/test".to_string()));
+            assert_eq!(args.commit, Some("abc123".to_string()));
+            assert_eq!(args.packages, Some(vec!["pkg-a".to_string(), "pkg-b".to_string()]));
+            assert_eq!(args.bump, Some("major".to_string()));
+            assert_eq!(args.env, Some(vec!["staging".to_string()]));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation Tests
+    // -------------------------------------------------------------------------
+
+    mod validation_tests {
+        use super::*;
+        use std::fs;
+        use tempfile::TempDir;
+
+        #[test]
+        fn test_validate_update_params_valid() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetUpdateParams::new(temp_dir.path().to_str().unwrap())
+                .with_id("feature/test");
+
+            let result = validate_update_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_update_params_missing_id() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetUpdateParams::new(temp_dir.path().to_str().unwrap());
+
+            let result = validate_update_params(&params);
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("id is required"));
+        }
+
+        #[test]
+        fn test_validate_update_params_nonexistent_path() {
+            let params = ChangesetUpdateParams::new("/nonexistent/path/that/does/not/exist")
+                .with_id("feature/test");
+
+            let result = validate_update_params(&params);
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "ENOENT");
+        }
+
+        #[test]
+        fn test_validate_update_params_empty_root() {
+            let params = ChangesetUpdateParams::new("").with_id("feature/test");
+
+            let result = validate_update_params(&params);
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+        }
+
+        #[test]
+        fn test_validate_update_params_file_not_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let file_path = temp_dir.path().join("test.txt");
+            fs::write(&file_path, "test").unwrap();
+
+            let params =
+                ChangesetUpdateParams::new(file_path.to_str().unwrap()).with_id("feature/test");
+
+            let result = validate_update_params(&params);
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+        }
+
+        #[test]
+        fn test_validate_update_params_valid_bump_type() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetUpdateParams::new(temp_dir.path().to_str().unwrap())
+                .with_id("feature/test")
+                .with_bump("minor");
+
+            let result = validate_update_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_update_params_invalid_bump_type() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetUpdateParams::new(temp_dir.path().to_str().unwrap())
+                .with_id("feature/test")
+                .with_bump("invalid");
+
+            let result = validate_update_params(&params);
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("invalid bump type"));
+        }
+
+        #[test]
+        fn test_validate_update_params_all_bump_types() {
+            let temp_dir = TempDir::new().unwrap();
+            let root = temp_dir.path().to_str().unwrap();
+
+            for bump in &["major", "minor", "patch", "none"] {
+                let params =
+                    ChangesetUpdateParams::new(root).with_id("feature/test").with_bump(*bump);
+                let result = validate_update_params(&params);
+                assert!(result.is_ok(), "Bump type '{bump}' should be valid");
+            }
+        }
+
+        #[test]
+        fn test_validate_update_params_with_all_options() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetUpdateParams::new(temp_dir.path().to_str().unwrap())
+                .with_id("feature/test")
+                .with_commit("abc123")
+                .with_packages(vec!["pkg-a".to_string()])
+                .with_bump("major")
+                .with_environments(vec!["staging".to_string()]);
+
+            let result = validate_update_params(&params);
+            assert!(result.is_ok());
+        }
+    }
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -139,7 +139,8 @@ pub use commands::init;
 // Changeset commands (Story 4.2-4.8)
 // Story 4.2: changesetAdd
 pub use commands::changeset_add;
-// TODO: will be implemented on story 4.3 (changesetUpdate)
+// Story 4.3: changesetUpdate
+pub use commands::changeset_update;
 // TODO: will be implemented on story 4.4 (changesetList)
 // TODO: will be implemented on story 4.5 (changesetShow)
 // TODO: will be implemented on story 4.6 (changesetRemove)

--- a/crates/node/src/tests.rs
+++ b/crates/node/src/tests.rs
@@ -2512,12 +2512,15 @@ mod changeset_api_response_tests {
 
     #[test]
     fn test_changeset_update_api_response_success() {
-        let summary = UpdateSummaryInfo::new(
-            2,
-            vec!["@scope/new".to_string()],
-            vec!["@scope/existing".to_string()],
+        let summary = UpdateSummaryInfo::new(2, 1, true, 1);
+        let changeset = ChangesetDetailInfo::new(
+            "feature-api",
+            "feature/api",
+            "major",
+            "2024-01-15T10:00:00Z",
+            "2024-01-15T12:00:00Z",
         );
-        let data = ChangesetUpdateData::success(summary);
+        let data = ChangesetUpdateData::success(summary, changeset);
         let response = ChangesetUpdateApiResponse::success(data);
 
         assert!(response.success);
@@ -2527,7 +2530,15 @@ mod changeset_api_response_tests {
 
     #[test]
     fn test_changeset_update_api_response_no_changes() {
-        let data = ChangesetUpdateData::no_changes();
+        let summary = UpdateSummaryInfo::empty();
+        let changeset = ChangesetDetailInfo::new(
+            "feature-api",
+            "feature/api",
+            "minor",
+            "2024-01-15T10:00:00Z",
+            "2024-01-15T10:00:00Z",
+        );
+        let data = ChangesetUpdateData::new(false, summary, changeset);
         let response = ChangesetUpdateApiResponse::success(data);
 
         assert!(response.success);
@@ -3042,24 +3053,24 @@ mod changeset_data_tests {
 
     #[test]
     fn test_update_summary_info_new() {
-        let summary = UpdateSummaryInfo::new(
-            3,
-            vec!["@scope/new1".to_string(), "@scope/new2".to_string()],
-            vec!["@scope/existing".to_string()],
-        );
+        let summary = UpdateSummaryInfo::new(3, 2, true, 1);
 
-        assert_eq!(summary.commits_added, 3);
-        assert_eq!(summary.new_packages.len(), 2);
-        assert_eq!(summary.existing_packages.len(), 1);
+        assert_eq!(summary.packages_added, 3);
+        assert_eq!(summary.commits_added, 2);
+        assert!(summary.bump_updated);
+        assert_eq!(summary.environments_added, 1);
+        assert!(summary.has_changes());
     }
 
     #[test]
     fn test_update_summary_info_empty() {
         let summary = UpdateSummaryInfo::empty();
 
+        assert_eq!(summary.packages_added, 0);
         assert_eq!(summary.commits_added, 0);
-        assert!(summary.new_packages.is_empty());
-        assert!(summary.existing_packages.is_empty());
+        assert!(!summary.bump_updated);
+        assert_eq!(summary.environments_added, 0);
+        assert!(!summary.has_changes());
     }
 
     // ========================================================================
@@ -3159,27 +3170,53 @@ mod changeset_data_tests {
 
     #[test]
     fn test_changeset_update_data_success() {
-        let summary = UpdateSummaryInfo::new(1, vec!["@scope/new".to_string()], vec![]);
-        let data = ChangesetUpdateData::success(summary);
+        let summary = UpdateSummaryInfo::new(1, 1, false, 0);
+        let changeset = ChangesetDetailInfo::new(
+            "feature-api",
+            "feature/api",
+            "minor",
+            "2024-01-15T10:00:00Z",
+            "2024-01-15T12:00:00Z",
+        );
+        let data = ChangesetUpdateData::success(summary, changeset);
 
         assert!(data.updated);
+        assert_eq!(data.summary.packages_added, 1);
         assert_eq!(data.summary.commits_added, 1);
+        assert_eq!(data.changeset.branch, "feature/api");
     }
 
     #[test]
     fn test_changeset_update_data_no_changes() {
-        let data = ChangesetUpdateData::no_changes();
+        let summary = UpdateSummaryInfo::empty();
+        let changeset = ChangesetDetailInfo::new(
+            "feature-api",
+            "feature/api",
+            "minor",
+            "2024-01-15T10:00:00Z",
+            "2024-01-15T10:00:00Z",
+        );
+        let data = ChangesetUpdateData::new(false, summary, changeset);
 
         assert!(!data.updated);
         assert_eq!(data.summary.commits_added, 0);
+        assert!(!data.summary.has_changes());
     }
 
     #[test]
     fn test_changeset_update_data_new() {
-        let summary = UpdateSummaryInfo::empty();
-        let data = ChangesetUpdateData::new(true, summary);
+        let summary = UpdateSummaryInfo::new(0, 0, true, 0);
+        let changeset = ChangesetDetailInfo::new(
+            "feature-api",
+            "feature/api",
+            "major",
+            "2024-01-15T10:00:00Z",
+            "2024-01-15T12:00:00Z",
+        );
+        let data = ChangesetUpdateData::new(true, summary, changeset);
 
         assert!(data.updated);
+        assert!(data.summary.bump_updated);
     }
 
     // ========================================================================

--- a/crates/node/src/types/changeset.rs
+++ b/crates/node/src/types/changeset.rs
@@ -1236,48 +1236,109 @@ impl ChangesetDetailInfo {
 
 /// Summary of a changeset update operation.
 ///
-/// Contains counts and lists of what was added or modified during
-/// a changeset update.
+/// Contains counts of what was added or modified during a changeset update.
+/// This structure mirrors the CLI's `UpdateSummary` response.
 ///
 /// # TypeScript Definition
 ///
 /// ```typescript
 /// interface UpdateSummaryInfo {
+///   packagesAdded: number;
 ///   commitsAdded: number;
-///   newPackages: string[];
-///   existingPackages: string[];
+///   bumpUpdated: boolean;
+///   environmentsAdded: number;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// // Successful update response
+/// if (result.success) {
+///   const summary = result.data.summary;
+///   console.log(`Packages added: ${summary.packagesAdded}`);
+///   console.log(`Commits added: ${summary.commitsAdded}`);
+///   console.log(`Bump updated: ${summary.bumpUpdated}`);
+///   console.log(`Environments added: ${summary.environmentsAdded}`);
 /// }
 /// ```
 #[allow(dead_code)]
 #[napi(object)]
 #[derive(Debug, Clone, Serialize)]
 pub struct UpdateSummaryInfo {
+    /// Number of packages added to the changeset.
+    ///
+    /// Counts only newly added packages; packages that already existed
+    /// in the changeset are not included in this count.
+    pub packages_added: u32,
+
     /// Number of commits added to the changeset.
+    ///
+    /// Typically 0 or 1, as only one commit can be added per update call.
     pub commits_added: u32,
 
-    /// Packages that were newly added to the changeset.
-    pub new_packages: Vec<String>,
+    /// Whether the bump type was changed.
+    ///
+    /// `true` if the bump type was modified (e.g., from `patch` to `minor`),
+    /// `false` if the bump type remained the same or was not specified.
+    pub bump_updated: bool,
 
-    /// Packages that already existed in the changeset.
-    pub existing_packages: Vec<String>,
+    /// Number of environments added to the changeset.
+    ///
+    /// Counts only newly added environments; environments that already
+    /// existed in the changeset are not included in this count.
+    pub environments_added: u32,
 }
 
 #[allow(dead_code)]
 impl UpdateSummaryInfo {
-    /// Creates a new `UpdateSummaryInfo`.
+    /// Creates a new `UpdateSummaryInfo` with specified values.
+    ///
+    /// # Arguments
+    ///
+    /// * `packages_added` - Number of packages added
+    /// * `commits_added` - Number of commits added
+    /// * `bump_updated` - Whether the bump type was changed
+    /// * `environments_added` - Number of environments added
+    ///
+    /// # Returns
+    ///
+    /// A new `UpdateSummaryInfo` instance.
     #[must_use]
     pub fn new(
+        packages_added: u32,
         commits_added: u32,
-        new_packages: Vec<String>,
-        existing_packages: Vec<String>,
+        bump_updated: bool,
+        environments_added: u32,
     ) -> Self {
-        Self { commits_added, new_packages, existing_packages }
+        Self { packages_added, commits_added, bump_updated, environments_added }
     }
 
     /// Creates an empty update summary (no changes).
+    ///
+    /// Used when an update operation results in no actual changes
+    /// (e.g., all specified values already existed in the changeset).
+    ///
+    /// # Returns
+    ///
+    /// An `UpdateSummaryInfo` with all counts at zero and `bump_updated` as `false`.
     #[must_use]
     pub fn empty() -> Self {
-        Self { commits_added: 0, new_packages: Vec::new(), existing_packages: Vec::new() }
+        Self { packages_added: 0, commits_added: 0, bump_updated: false, environments_added: 0 }
+    }
+
+    /// Returns `true` if any changes were made.
+    ///
+    /// # Returns
+    ///
+    /// `true` if at least one package, commit, or environment was added,
+    /// or if the bump type was updated.
+    #[must_use]
+    pub fn has_changes(&self) -> bool {
+        self.packages_added > 0
+            || self.commits_added > 0
+            || self.bump_updated
+            || self.environments_added > 0
     }
 }
 
@@ -1484,7 +1545,8 @@ impl ChangesetAddData {
 
 /// Response data for the changeset update command.
 ///
-/// Contains the result of the update operation.
+/// Contains the result of the update operation, including a summary of what
+/// was changed and the current state of the changeset after the update.
 ///
 /// # TypeScript Definition
 ///
@@ -1492,6 +1554,24 @@ impl ChangesetAddData {
 /// interface ChangesetUpdateData {
 ///   updated: boolean;
 ///   summary: UpdateSummaryInfo;
+///   changeset: ChangesetDetailInfo;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// const result = await changesetUpdate({
+///   root: '.',
+///   id: 'feature/new-api',
+///   packages: ['@scope/new-package'],
+///   bump: 'minor'
+/// });
+///
+/// if (result.success) {
+///   console.log(`Updated: ${result.data.updated}`);
+///   console.log(`Packages added: ${result.data.summary.packagesAdded}`);
+///   console.log(`Current packages: ${result.data.changeset.packages.join(', ')}`);
 /// }
 /// ```
 #[allow(dead_code)]
@@ -1499,30 +1579,55 @@ impl ChangesetAddData {
 #[derive(Debug, Clone, Serialize)]
 pub struct ChangesetUpdateData {
     /// Whether the update was performed.
+    ///
+    /// `true` if at least one change was applied to the changeset,
+    /// `false` if all specified values already existed.
     pub updated: bool,
 
     /// Summary of what was updated.
+    ///
+    /// Contains counts of packages, commits, and environments added,
+    /// as well as whether the bump type was changed.
     pub summary: UpdateSummaryInfo,
+
+    /// The updated changeset details.
+    ///
+    /// Contains the complete state of the changeset after the update,
+    /// including all packages, commits, environments, and timestamps.
+    pub changeset: ChangesetDetailInfo,
 }
 
 #[allow(dead_code)]
 impl ChangesetUpdateData {
-    /// Creates a new `ChangesetUpdateData`.
+    /// Creates a new `ChangesetUpdateData` with all fields.
+    ///
+    /// # Arguments
+    ///
+    /// * `updated` - Whether any changes were applied
+    /// * `summary` - Summary of what was updated
+    /// * `changeset` - The updated changeset details
+    ///
+    /// # Returns
+    ///
+    /// A new `ChangesetUpdateData` instance.
     #[must_use]
-    pub fn new(updated: bool, summary: UpdateSummaryInfo) -> Self {
-        Self { updated, summary }
+    pub fn new(updated: bool, summary: UpdateSummaryInfo, changeset: ChangesetDetailInfo) -> Self {
+        Self { updated, summary, changeset }
     }
 
     /// Creates a successful update response.
+    ///
+    /// # Arguments
+    ///
+    /// * `summary` - Summary of what was updated
+    /// * `changeset` - The updated changeset details
+    ///
+    /// # Returns
+    ///
+    /// A `ChangesetUpdateData` with `updated` set to `true`.
     #[must_use]
-    pub fn success(summary: UpdateSummaryInfo) -> Self {
-        Self { updated: true, summary }
-    }
-
-    /// Creates a no-op response (no changes made).
-    #[must_use]
-    pub fn no_changes() -> Self {
-        Self { updated: false, summary: UpdateSummaryInfo::empty() }
+    pub fn success(summary: UpdateSummaryInfo, changeset: ChangesetDetailInfo) -> Self {
+        Self { updated: true, summary, changeset }
     }
 }
 

--- a/packages/workspace-tools/npm/darwin-arm64/package.json
+++ b/packages/workspace-tools/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-arm64",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/darwin-x64/package.json
+++ b/packages/workspace-tools/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-x64",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-gnu",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-musl",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-gnu",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-musl",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/win32-arm64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-arm64-msvc",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/win32-x64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-x64-msvc",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Bindings for node from crate workspace-tools",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/types/index.d.cts",

--- a/packages/workspace-tools/src/binding.d.ts
+++ b/packages/workspace-tools/src/binding.d.ts
@@ -1005,6 +1005,94 @@ export interface ChangesetShowParams {
 }
 
 /**
+ * Update an existing changeset in the workspace.
+ *
+ * Modifies an existing changeset by adding packages, commits, environments,
+ * or changing the bump type. The changeset is identified by the `id` parameter,
+ * which corresponds to the branch name.
+ *
+ * This function always operates in non-interactive mode. The `id` parameter
+ * is required since auto-detection of the current git branch is not reliable
+ * in programmatic contexts.
+ *
+ * @param params - Changeset update parameters containing:
+ *   - `root`: Workspace root directory path (required)
+ *   - `configPath`: Optional custom config file path
+ *   - `id`: Branch name or changeset ID (required)
+ *   - `commit`: Optional commit hash to add
+ *   - `packages`: Optional list of packages to add
+ *   - `bump`: Optional new bump type (major, minor, patch)
+ *   - `environments`: Optional list of environments to add
+ *
+ * @returns `Promise<ChangesetUpdateApiResponse>` containing:
+ *   - On success: `{ success: true, data: ChangesetUpdateData }`
+ *   - On failure: `{ success: false, error: ErrorInfo }`
+ *
+ * @example Add packages to an existing changeset
+ * ```typescript
+ * const result = await changesetUpdate({
+ *   root: '/path/to/workspace',
+ *   id: 'feature/new-api',
+ *   packages: ['@scope/new-package']
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Updated: ${result.data.updated}`);
+ *   console.log(`Packages added: ${result.data.summary.packagesAdded}`);
+ * }
+ * ```
+ *
+ * @example Add a commit and change bump type
+ * ```typescript
+ * const result = await changesetUpdate({
+ *   root: '/path/to/workspace',
+ *   id: 'feature/breaking-change',
+ *   commit: 'abc123def456',
+ *   bump: 'major'
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Bump updated: ${result.data.summary.bumpUpdated}`);
+ *   console.log(`Current bump: ${result.data.changeset.bump}`);
+ * }
+ * ```
+ *
+ * @example Add environments
+ * ```typescript
+ * const result = await changesetUpdate({
+ *   root: '/path/to/workspace',
+ *   id: 'feature/deploy',
+ *   environments: ['staging', 'production']
+ * });
+ * ```
+ *
+ * @example Error handling
+ * ```typescript
+ * const result = await changesetUpdate({
+ *   root: '/path/to/workspace',
+ *   id: 'nonexistent-branch'
+ * });
+ *
+ * if (!result.success) {
+ *   switch (result.error.code) {
+ *     case 'ENOENT':
+ *       console.error('Path or changeset not found');
+ *       break;
+ *     case 'EVALIDATION':
+ *       console.error('Invalid parameters:', result.error.message);
+ *       break;
+ *     case 'EEXECUTION':
+ *       console.error('Update failed:', result.error.message);
+ *       break;
+ *     default:
+ *       console.error(`Error: ${result.error.message}`);
+ *   }
+ * }
+ * ```
+ */
+export declare function changesetUpdate(params: ChangesetUpdateParams): Promise<ChangesetUpdateApiResponse>
+
+/**
  * API response for the changeset update command.
  *
  * Wraps `ChangesetUpdateData` with success/error handling.
@@ -1031,7 +1119,8 @@ export interface ChangesetUpdateApiResponse {
 /**
  * Response data for the changeset update command.
  *
- * Contains the result of the update operation.
+ * Contains the result of the update operation, including a summary of what
+ * was changed and the current state of the changeset after the update.
  *
  * # TypeScript Definition
  *
@@ -1039,14 +1128,49 @@ export interface ChangesetUpdateApiResponse {
  * interface ChangesetUpdateData {
  *   updated: boolean;
  *   summary: UpdateSummaryInfo;
+ *   changeset: ChangesetDetailInfo;
+ * }
+ * ```
+ *
+ * # Examples
+ *
+ * ```typescript
+ * const result = await changesetUpdate({
+ *   root: '.',
+ *   id: 'feature/new-api',
+ *   packages: ['@scope/new-package'],
+ *   bump: 'minor'
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Updated: ${result.data.updated}`);
+ *   console.log(`Packages added: ${result.data.summary.packagesAdded}`);
+ *   console.log(`Current packages: ${result.data.changeset.packages.join(', ')}`);
  * }
  * ```
  */
 export interface ChangesetUpdateData {
-  /** Whether the update was performed. */
+  /**
+   * Whether the update was performed.
+   *
+   * `true` if at least one change was applied to the changeset,
+   * `false` if all specified values already existed.
+   */
   updated: boolean
-  /** Summary of what was updated. */
+  /**
+   * Summary of what was updated.
+   *
+   * Contains counts of packages, commits, and environments added,
+   * as well as whether the bump type was changed.
+   */
   summary: UpdateSummaryInfo
+  /**
+   * The updated changeset details.
+   *
+   * Contains the complete state of the changeset after the update,
+   * including all packages, commits, environments, and timestamps.
+   */
+  changeset: ChangesetDetailInfo
 }
 
 /**
@@ -2184,24 +2308,59 @@ export interface StatusParams {
 /**
  * Summary of a changeset update operation.
  *
- * Contains counts and lists of what was added or modified during
- * a changeset update.
+ * Contains counts of what was added or modified during a changeset update.
+ * This structure mirrors the CLI's `UpdateSummary` response.
  *
  * # TypeScript Definition
  *
  * ```typescript
  * interface UpdateSummaryInfo {
+ *   packagesAdded: number;
  *   commitsAdded: number;
- *   newPackages: string[];
- *   existingPackages: string[];
+ *   bumpUpdated: boolean;
+ *   environmentsAdded: number;
+ * }
+ * ```
+ *
+ * # Examples
+ *
+ * ```typescript
+ * // Successful update response
+ * if (result.success) {
+ *   const summary = result.data.summary;
+ *   console.log(`Packages added: ${summary.packagesAdded}`);
+ *   console.log(`Commits added: ${summary.commitsAdded}`);
+ *   console.log(`Bump updated: ${summary.bumpUpdated}`);
+ *   console.log(`Environments added: ${summary.environmentsAdded}`);
  * }
  * ```
  */
 export interface UpdateSummaryInfo {
-  /** Number of commits added to the changeset. */
+  /**
+   * Number of packages added to the changeset.
+   *
+   * Counts only newly added packages; packages that already existed
+   * in the changeset are not included in this count.
+   */
+  packagesAdded: number
+  /**
+   * Number of commits added to the changeset.
+   *
+   * Typically 0 or 1, as only one commit can be added per update call.
+   */
   commitsAdded: number
-  /** Packages that were newly added to the changeset. */
-  newPackages: Array<string>
-  /** Packages that already existed in the changeset. */
-  existingPackages: Array<string>
+  /**
+   * Whether the bump type was changed.
+   *
+   * `true` if the bump type was modified (e.g., from `patch` to `minor`),
+   * `false` if the bump type remained the same or was not specified.
+   */
+  bumpUpdated: boolean
+  /**
+   * Number of environments added to the changeset.
+   *
+   * Counts only newly added environments; environments that already
+   * existed in the changeset are not included in this count.
+   */
+  environmentsAdded: number
 }

--- a/packages/workspace-tools/src/binding.js
+++ b/packages/workspace-tools/src/binding.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm-eabi')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-ia32-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-arm64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@websublime/workspace-tools-darwin-universal')
       const bindingPackageVersion = require('@websublime/workspace-tools-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-musleabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-ppc64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-s390x-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.0.2' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.2 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -573,6 +573,7 @@ if (!nativeBinding) {
 
 module.exports = nativeBinding
 module.exports.changesetAdd = nativeBinding.changesetAdd
+module.exports.changesetUpdate = nativeBinding.changesetUpdate
 module.exports.getVersion = nativeBinding.getVersion
 module.exports.init = nativeBinding.init
 module.exports.status = nativeBinding.status

--- a/packages/workspace-tools/src/index.ts
+++ b/packages/workspace-tools/src/index.ts
@@ -11,7 +11,8 @@
  * - `status()` - Get workspace status information
  * - `init()` - Initialize workspace with changeset-based version management
  * - `changesetAdd()` - Add a new changeset to the workspace (Story 4.2)
- * - Changeset types for upcoming changeset commands (Stories 4.3-4.8)
+ * - `changesetUpdate()` - Update an existing changeset (Story 4.3)
+ * - Changeset types for upcoming changeset commands (Stories 4.4-4.8)
  *
  * ## How
  *
@@ -31,9 +32,9 @@
  */
 
 // Re-export all functions from bindings
-import { changesetAdd, getVersion, init, status } from './binding'
+import { changesetAdd, changesetUpdate, getVersion, init, status } from './binding'
 
-export { changesetAdd, getVersion, init, status }
+export { changesetAdd, changesetUpdate, getVersion, init, status }
 
 // Re-export all types from bindings
 export type {


### PR DESCRIPTION
- Add changesetUpdate function to update existing changesets
- Update UpdateSummaryInfo to match CLI's UpdateSummary structure
  - Fields: packagesAdded, commitsAdded, bumpUpdated, environmentsAdded
  - Add hasChanges() method
- Update ChangesetUpdateData to include changeset details
- Add CLI response types for parsing update command output
- Add validation requiring id parameter for NAPI context
- Add comprehensive tests (37 new tests)
- Regenerate Node.js bindings and update exports
- Sync platform-specific package versions to 2.0.4

Story 4.3 implementation complete with:
- Parameter validation (root path, id required, bump type)
- CLI output parsing and conversion to NAPI types
- Full TypeScript type definitions
- 100% clippy compliance