### PR TITLE
feat(WOR-TSK-185): implement changesetList NAPI function

### DIFF
--- a/crates/node/src/commands/changeset.rs
+++ b/crates/node/src/commands/changeset.rs
@@ -12,6 +12,7 @@
 //!
 //! - `changeset_add`: Creates a new changeset for the current branch
 //! - `changeset_update`: Updates an existing changeset with new packages, commits, bump type, or environments
+//! - `changeset_list`: Lists all pending changesets with optional filtering and sorting
 //!
 //! Each function follows this pattern:
 //! 1. Validates the input parameters
@@ -72,6 +73,22 @@
 //! } else {
 //!   console.error(`Error [${updateResult.error.code}]: ${updateResult.error.message}`);
 //! }
+//!
+//! // List all pending changesets
+//! const listResult = await changesetList({
+//!   root: '.',
+//!   filterBump: 'minor',
+//!   sort: 'date'
+//! });
+//!
+//! if (listResult.success) {
+//!   console.log(`Found ${listResult.data.count} changeset(s)`);
+//!   for (const cs of listResult.data.changesets) {
+//!     console.log(`- ${cs.branch}: ${cs.bump} (${cs.packages.length} packages)`);
+//!   }
+//! } else {
+//!   console.error(`Error [${listResult.error.code}]: ${listResult.error.message}`);
+//! }
 //! ```
 
 use std::io::Write;
@@ -84,12 +101,16 @@ use serde::Deserialize;
 use crate::error::ErrorInfo;
 use crate::types::changeset::{
     ChangesetAddApiResponse, ChangesetAddData, ChangesetAddParams, ChangesetDetailInfo,
+    ChangesetListApiResponse, ChangesetListData, ChangesetListItemInfo, ChangesetListParams,
     ChangesetUpdateApiResponse, ChangesetUpdateData, ChangesetUpdateParams, UpdateSummaryInfo,
+    VALID_SORT_OPTIONS,
 };
 use crate::validation::validators;
 
-use sublime_cli_tools::cli::commands::{ChangesetCreateArgs, ChangesetUpdateArgs};
-use sublime_cli_tools::commands::changeset::{execute_add, execute_update};
+use sublime_cli_tools::cli::commands::{
+    ChangesetCreateArgs, ChangesetListArgs, ChangesetUpdateArgs,
+};
+use sublime_cli_tools::commands::changeset::{execute_add, execute_list, execute_update};
 use sublime_cli_tools::output::{Output, OutputFormat};
 
 // ============================================================================
@@ -880,6 +901,385 @@ pub async fn changeset_update(params: ChangesetUpdateParams) -> ChangesetUpdateA
         Ok(Ok(data)) => ChangesetUpdateApiResponse::success(data),
         Ok(Err(error)) => ChangesetUpdateApiResponse::failure(error),
         Err(join_error) => ChangesetUpdateApiResponse::failure(ErrorInfo::execution(format!(
+            "Task execution failed: {join_error}"
+        ))),
+    }
+}
+
+// ============================================================================
+// Changeset List - CLI Response Types
+// ============================================================================
+
+/// CLI JSON response data for changeset list command.
+///
+/// This type mirrors the `ChangesetListResponse` structure from the CLI's
+/// list command, used for deserializing the captured JSON output.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliChangesetListResponseData {
+    /// Whether the operation succeeded.
+    #[allow(dead_code)]
+    pub(crate) success: bool,
+    /// List of changesets.
+    pub(crate) changesets: Vec<CliChangesetListItem>,
+    /// Total count of changesets.
+    #[allow(dead_code)]
+    pub(crate) total: usize,
+}
+
+/// CLI changeset list item structure.
+///
+/// Mirrors the `ChangesetListItem` structure from the CLI's list command.
+/// Field names use snake_case to match the JSON output format.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliChangesetListItem {
+    /// Branch name (also serves as unique identifier).
+    pub(crate) branch: String,
+    /// Version bump type (major, minor, patch, none).
+    pub(crate) bump: String,
+    /// List of affected packages.
+    pub(crate) packages: Vec<String>,
+    /// Target environments.
+    pub(crate) environments: Vec<String>,
+    /// Number of commits in the changeset.
+    #[allow(dead_code)]
+    pub(crate) commit_count: usize,
+    /// Creation timestamp (RFC3339 format).
+    pub(crate) created_at: String,
+    /// Last update timestamp (RFC3339 format).
+    pub(crate) updated_at: String,
+}
+
+// ============================================================================
+// Changeset List - Conversion Functions
+// ============================================================================
+
+/// Converts a CLI changeset list item to NAPI-compatible `ChangesetListItemInfo`.
+///
+/// This function converts the CLI's list item format to the NAPI type,
+/// preserving the `commit_count` field. For full commit details,
+/// use the `changesetShow` command.
+///
+/// # Arguments
+///
+/// * `cli_item` - The parsed CLI changeset list item
+///
+/// # Returns
+///
+/// A `ChangesetListItemInfo` instance suitable for returning to JavaScript.
+pub(crate) fn convert_list_item_to_napi(cli_item: CliChangesetListItem) -> ChangesetListItemInfo {
+    // Safe truncation: commit counts will never exceed u32::MAX in practice
+    #[allow(clippy::cast_possible_truncation)]
+    let commit_count = cli_item.commit_count as u32;
+
+    ChangesetListItemInfo {
+        // The id is derived from the branch name
+        id: cli_item.branch.clone(),
+        branch: cli_item.branch,
+        bump: cli_item.bump,
+        packages: cli_item.packages,
+        environments: cli_item.environments,
+        commit_count,
+        created_at: cli_item.created_at,
+        updated_at: cli_item.updated_at,
+    }
+}
+
+/// Converts CLI list response to NAPI-compatible `ChangesetListData`.
+///
+/// # Arguments
+///
+/// * `cli_data` - The parsed CLI list response data
+///
+/// # Returns
+///
+/// A `ChangesetListData` instance suitable for returning to JavaScript.
+pub(crate) fn convert_to_napi_list_data(
+    cli_data: CliChangesetListResponseData,
+) -> ChangesetListData {
+    let changesets: Vec<ChangesetListItemInfo> =
+        cli_data.changesets.into_iter().map(convert_list_item_to_napi).collect();
+
+    ChangesetListData::new(changesets)
+}
+
+/// Parses the JSON response from the CLI list command and converts it to NAPI types.
+///
+/// # Arguments
+///
+/// * `json_bytes` - The raw JSON bytes captured from CLI output
+///
+/// # Returns
+///
+/// * `Ok(ChangesetListData)` - Successfully parsed and converted list data
+/// * `Err(ErrorInfo)` - Parsing failed or CLI returned an error
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The JSON is malformed or cannot be parsed
+/// - The CLI returned `success: false` with an error message
+/// - The CLI returned `success: true` but `data` is missing
+pub(crate) fn parse_changeset_list_response(
+    json_bytes: &[u8],
+) -> Result<ChangesetListData, ErrorInfo> {
+    // Convert bytes to string first for better error messages
+    let json_str = std::str::from_utf8(json_bytes)
+        .map_err(|e| ErrorInfo::execution(format!("Invalid UTF-8 in CLI response: {e}")))?;
+
+    // Handle empty response
+    if json_str.trim().is_empty() {
+        return Err(ErrorInfo::execution("CLI returned empty response"));
+    }
+
+    // Parse the JSON response
+    let response: CliJsonResponse<CliChangesetListResponseData> = serde_json::from_str(json_str)
+        .map_err(|e| {
+            ErrorInfo::execution(format!(
+                "Failed to parse CLI JSON response: {e} (length={})",
+                json_str.len()
+            ))
+        })?;
+
+    // Check for CLI-level errors
+    if !response.success {
+        let error_message = response.error.unwrap_or_else(|| "Unknown CLI error".to_string());
+        return Err(ErrorInfo::execution(error_message));
+    }
+
+    // Extract and convert data
+    let cli_data =
+        response.data.ok_or_else(|| ErrorInfo::execution("CLI returned success but no data"))?;
+
+    Ok(convert_to_napi_list_data(cli_data))
+}
+
+// ============================================================================
+// Changeset List - Parameter Validation
+// ============================================================================
+
+/// Validates changeset list command parameters.
+///
+/// Ensures the root path is valid and that optional filter/sort parameters
+/// have valid values before executing the CLI command.
+///
+/// # Arguments
+///
+/// * `params` - The changeset list parameters to validate
+///
+/// # Returns
+///
+/// * `Ok(PathBuf)` - The validated root path
+/// * `Err(ErrorInfo)` - Validation failed
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The root path is empty, doesn't exist, or is not a directory
+/// - The `filter_bump` parameter (if provided) is not a valid bump type
+/// - The `sort` parameter (if provided) is not a valid sort option
+pub(crate) fn validate_list_params(params: &ChangesetListParams) -> Result<PathBuf, ErrorInfo> {
+    // Validate root path exists and is a directory
+    validators::root(&params.root)?;
+
+    // Validate bump type filter if provided
+    if let Some(ref bump) = params.filter_bump {
+        validators::bump_type_info(bump)?;
+    }
+
+    // Validate sort option if provided
+    if let Some(ref sort) = params.sort
+        && !VALID_SORT_OPTIONS.contains(&sort.as_str())
+    {
+        return Err(ErrorInfo::validation(
+            format!(
+                "invalid sort option '{}'. Valid options are: {}",
+                sort,
+                VALID_SORT_OPTIONS.join(", ")
+            ),
+            Some("sort"),
+        ));
+    }
+
+    Ok(PathBuf::from(&params.root))
+}
+
+/// Converts NAPI parameters to CLI arguments.
+///
+/// This function transforms the NAPI-friendly `ChangesetListParams` into the
+/// CLI's `ChangesetListArgs` structure.
+///
+/// # Arguments
+///
+/// * `params` - The NAPI changeset list parameters
+///
+/// # Returns
+///
+/// A `ChangesetListArgs` instance ready for CLI execution.
+pub(crate) fn convert_list_params_to_args(params: &ChangesetListParams) -> ChangesetListArgs {
+    ChangesetListArgs {
+        filter_package: params.filter_package.clone(),
+        filter_bump: params.filter_bump.clone(),
+        filter_env: params.filter_env.clone(),
+        // Default to "date" if not provided (matches CLI default)
+        sort: params.sort.clone().unwrap_or_else(|| "date".to_string()),
+    }
+}
+
+// ============================================================================
+// Changeset List - NAPI Function
+// ============================================================================
+
+/// List all pending changesets in the workspace.
+///
+/// Retrieves all pending (not yet released) changesets with optional filtering
+/// by package, bump type, or environment. Results can be sorted by date, branch
+/// name, or bump type.
+///
+/// @param params - Changeset list parameters containing:
+///   - `root`: Workspace root directory path (required)
+///   - `configPath`: Optional custom config file path
+///   - `filterPackage`: Optional filter by package name
+///   - `filterBump`: Optional filter by bump type (major, minor, patch)
+///   - `filterEnv`: Optional filter by environment
+///   - `sort`: Sort order (date, branch, bump). Defaults to "date"
+///
+/// @returns `Promise<ChangesetListApiResponse>` containing:
+///   - On success: `{ success: true, data: ChangesetListData }`
+///   - On failure: `{ success: false, error: ErrorInfo }`
+///
+/// @example List all changesets
+/// ```typescript
+/// const result = await changesetList({
+///   root: '/path/to/workspace'
+/// });
+///
+/// if (result.success) {
+///   console.log(`Found ${result.data.count} changeset(s)`);
+///   for (const cs of result.data.changesets) {
+///     console.log(`- ${cs.branch}: ${cs.bump}`);
+///   }
+/// }
+/// ```
+///
+/// @example Filter by bump type
+/// ```typescript
+/// const result = await changesetList({
+///   root: '/path/to/workspace',
+///   filterBump: 'major'
+/// });
+///
+/// if (result.success) {
+///   console.log('Major version changesets:');
+///   result.data.changesets.forEach(cs => {
+///     console.log(`  ${cs.branch}: ${cs.packages.join(', ')}`);
+///   });
+/// }
+/// ```
+///
+/// @example Filter by package
+/// ```typescript
+/// const result = await changesetList({
+///   root: '/path/to/workspace',
+///   filterPackage: '@scope/core'
+/// });
+///
+/// if (result.success) {
+///   console.log(`Changesets affecting @scope/core: ${result.data.count}`);
+/// }
+/// ```
+///
+/// @example Sort by branch name
+/// ```typescript
+/// const result = await changesetList({
+///   root: '/path/to/workspace',
+///   sort: 'branch'
+/// });
+/// ```
+///
+/// @example Filter by environment
+/// ```typescript
+/// const result = await changesetList({
+///   root: '/path/to/workspace',
+///   filterEnv: 'production'
+/// });
+/// ```
+///
+/// @example Error handling
+/// ```typescript
+/// const result = await changesetList({
+///   root: '/nonexistent/path'
+/// });
+///
+/// if (!result.success) {
+///   switch (result.error.code) {
+///     case 'ENOENT':
+///       console.error('Path not found');
+///       break;
+///     case 'EVALIDATION':
+///       console.error('Invalid parameters:', result.error.message);
+///       break;
+///     case 'ECONFIG':
+///       console.error('Workspace not initialized');
+///       break;
+///     default:
+///       console.error(`Error: ${result.error.message}`);
+///   }
+/// }
+/// ```
+#[napi(js_name = "changesetList")]
+pub async fn changeset_list(params: ChangesetListParams) -> ChangesetListApiResponse {
+    // 1. Validate parameters (synchronous validation before spawning)
+    let root_path = match validate_list_params(&params) {
+        Ok(path) => path,
+        Err(error) => return ChangesetListApiResponse::failure(error),
+    };
+
+    // 2. Prepare config path
+    let config_path: Option<PathBuf> = params.config_path.as_ref().map(PathBuf::from);
+
+    // 3. Convert NAPI params to CLI args
+    let args = convert_list_params_to_args(&params);
+
+    // 4. Execute CLI command in a blocking task
+    // The CLI's execute_list uses types that are not Send/Sync (RefCell, git2::Repository),
+    // so we must run it on a blocking thread via spawn_blocking.
+    let result = tokio::task::spawn_blocking(move || {
+        // Create a new tokio runtime for the blocking context
+        // This is necessary because execute_list is async but we're in a blocking context
+        let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                return Err(ErrorInfo::execution(format!("Failed to create runtime: {e}")));
+            }
+        };
+
+        rt.block_on(async {
+            // Create shared buffer for output capture
+            let buffer = SharedBuffer::new();
+
+            // Create Output with JSON format
+            let output = Output::new(OutputFormat::Json, buffer.clone(), true);
+
+            // Execute the CLI command
+            if let Err(cli_error) =
+                execute_list(&args, &output, Some(root_path.as_path()), config_path.as_deref())
+                    .await
+            {
+                return Err(ErrorInfo::from(cli_error));
+            }
+
+            // Extract and parse JSON
+            let json_bytes = buffer.take_bytes();
+            parse_changeset_list_response(&json_bytes)
+        })
+    })
+    .await;
+
+    // 5. Handle spawn_blocking result
+    match result {
+        Ok(Ok(data)) => ChangesetListApiResponse::success(data),
+        Ok(Err(error)) => ChangesetListApiResponse::failure(error),
+        Err(join_error) => ChangesetListApiResponse::failure(ErrorInfo::execution(format!(
             "Task execution failed: {join_error}"
         ))),
     }

--- a/crates/node/src/commands/mod.rs
+++ b/crates/node/src/commands/mod.rs
@@ -70,7 +70,8 @@ pub(crate) mod changeset;
 pub use changeset::changeset_add;
 // Story 4.3: changesetUpdate
 pub use changeset::changeset_update;
-// TODO: will be implemented on story 4.4 (changesetList)
+// Story 4.4: changesetList
+pub use changeset::changeset_list;
 // TODO: will be implemented on story 4.5 (changesetShow)
 // TODO: will be implemented on story 4.6 (changesetRemove)
 // TODO: will be implemented on story 4.7 (changesetHistory)

--- a/crates/node/src/commands/tests.rs
+++ b/crates/node/src/commands/tests.rs
@@ -1899,3 +1899,489 @@ mod changeset_update_tests {
         }
     }
 }
+
+// =============================================================================
+// Changeset List Tests (Story 4.4)
+// =============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod changeset_list_tests {
+    use std::io::Write;
+
+    use crate::commands::changeset::{
+        CliChangesetListItem, CliChangesetListResponseData, SharedBuffer,
+        convert_list_item_to_napi, convert_list_params_to_args, convert_to_napi_list_data,
+        parse_changeset_list_response, validate_list_params,
+    };
+    use crate::types::changeset::{ChangesetListParams, VALID_SORT_OPTIONS};
+
+    // -------------------------------------------------------------------------
+    // SharedBuffer Tests (Reused from changeset_add, but included for completeness)
+    // -------------------------------------------------------------------------
+
+    mod shared_buffer_tests {
+        use super::*;
+
+        #[test]
+        fn test_shared_buffer_new() {
+            let buffer = SharedBuffer::new();
+            assert!(buffer.take_bytes().is_empty());
+        }
+
+        #[test]
+        fn test_shared_buffer_write() {
+            let mut buffer = SharedBuffer::new();
+            let written = buffer.write(b"hello").unwrap();
+            assert_eq!(written, 5);
+            assert_eq!(buffer.take_bytes(), b"hello");
+        }
+
+        #[test]
+        fn test_shared_buffer_multiple_writes() {
+            let mut buffer = SharedBuffer::new();
+            let _ = buffer.write(b"hello ");
+            let _ = buffer.write(b"world");
+            assert_eq!(buffer.take_bytes(), b"hello world");
+        }
+
+        #[test]
+        fn test_shared_buffer_clone_shares_data() {
+            let mut buffer = SharedBuffer::new();
+            let buffer_clone = buffer.clone();
+
+            let _ = buffer.write(b"test data");
+
+            // Both should see the same data
+            assert_eq!(buffer.take_bytes(), b"test data");
+            assert_eq!(buffer_clone.take_bytes(), b"test data");
+        }
+
+        #[test]
+        fn test_shared_buffer_flush() {
+            let mut buffer = SharedBuffer::new();
+            // Flush should always succeed (no-op for Vec)
+            assert!(buffer.flush().is_ok());
+        }
+
+        #[test]
+        fn test_shared_buffer_take_bytes_preserves_data() {
+            let mut buffer = SharedBuffer::new();
+            let _ = buffer.write(b"preserved");
+
+            // take_bytes clones, so data is preserved
+            let first_take = buffer.take_bytes();
+            let second_take = buffer.take_bytes();
+            assert_eq!(first_take, second_take);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Parse Response Tests
+    // -------------------------------------------------------------------------
+
+    mod parse_response_tests {
+        use super::*;
+
+        #[test]
+        fn test_parse_changeset_list_response_success() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "success": true,
+                    "changesets": [
+                        {
+                            "branch": "feature/new-api",
+                            "bump": "minor",
+                            "packages": ["@scope/core", "@scope/utils"],
+                            "environments": ["staging"],
+                            "commit_count": 3,
+                            "created_at": "2024-01-15T10:30:00Z",
+                            "updated_at": "2024-01-15T14:45:00Z"
+                        },
+                        {
+                            "branch": "feature/breaking-change",
+                            "bump": "major",
+                            "packages": ["@scope/api"],
+                            "environments": ["production"],
+                            "commit_count": 1,
+                            "created_at": "2024-01-14T09:00:00Z",
+                            "updated_at": "2024-01-14T09:00:00Z"
+                        }
+                    ],
+                    "total": 2
+                }
+            }"#;
+
+            let result = parse_changeset_list_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            assert_eq!(data.count, 2);
+            assert_eq!(data.changesets.len(), 2);
+
+            // Check first changeset
+            let first = &data.changesets[0];
+            assert_eq!(first.branch, "feature/new-api");
+            assert_eq!(first.bump, "minor");
+            assert_eq!(first.packages, vec!["@scope/core", "@scope/utils"]);
+            assert_eq!(first.environments, vec!["staging"]);
+            assert_eq!(first.commit_count, 3);
+            assert_eq!(first.created_at, "2024-01-15T10:30:00Z");
+            assert_eq!(first.updated_at, "2024-01-15T14:45:00Z");
+
+            // Check second changeset
+            let second = &data.changesets[1];
+            assert_eq!(second.branch, "feature/breaking-change");
+            assert_eq!(second.bump, "major");
+        }
+
+        #[test]
+        fn test_parse_changeset_list_response_empty_list() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "success": true,
+                    "changesets": [],
+                    "total": 0
+                }
+            }"#;
+
+            let result = parse_changeset_list_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            assert_eq!(data.count, 0);
+            assert!(data.changesets.is_empty());
+        }
+
+        #[test]
+        fn test_parse_changeset_list_response_cli_error() {
+            let json = r#"{
+                "success": false,
+                "error": "Workspace not initialized"
+            }"#;
+
+            let result = parse_changeset_list_response(json.as_bytes());
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EEXEC");
+            assert!(error.message.contains("Workspace not initialized"));
+        }
+
+        #[test]
+        fn test_parse_changeset_list_response_empty() {
+            let result = parse_changeset_list_response(b"");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("empty response"));
+        }
+
+        #[test]
+        fn test_parse_changeset_list_response_whitespace_only() {
+            let result = parse_changeset_list_response(b"   \n\t  ");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("empty response"));
+        }
+
+        #[test]
+        fn test_parse_changeset_list_response_invalid_json() {
+            let result = parse_changeset_list_response(b"not valid json");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Failed to parse CLI JSON response"));
+        }
+
+        #[test]
+        fn test_parse_changeset_list_response_invalid_utf8() {
+            let invalid_utf8 = vec![0xff, 0xfe, 0x00, 0x01];
+            let result = parse_changeset_list_response(&invalid_utf8);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Invalid UTF-8"));
+        }
+
+        #[test]
+        fn test_parse_changeset_list_response_success_no_data() {
+            let json = r#"{"success": true}"#;
+            let result = parse_changeset_list_response(json.as_bytes());
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("success but no data"));
+        }
+
+        #[test]
+        fn test_parse_changeset_list_response_cli_error_no_message() {
+            let json = r#"{"success": false}"#;
+            let result = parse_changeset_list_response(json.as_bytes());
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Unknown CLI error"));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Conversion Tests
+    // -------------------------------------------------------------------------
+
+    mod conversion_tests {
+        use super::*;
+
+        #[test]
+        fn test_convert_list_item_to_napi() {
+            let cli_item = CliChangesetListItem {
+                branch: "feature/test".to_string(),
+                bump: "minor".to_string(),
+                packages: vec!["@scope/pkg1".to_string(), "@scope/pkg2".to_string()],
+                environments: vec!["staging".to_string()],
+                commit_count: 5,
+                created_at: "2024-01-15T10:00:00Z".to_string(),
+                updated_at: "2024-01-15T12:00:00Z".to_string(),
+            };
+
+            let result = convert_list_item_to_napi(cli_item);
+
+            assert_eq!(result.id, "feature/test");
+            assert_eq!(result.branch, "feature/test");
+            assert_eq!(result.bump, "minor");
+            assert_eq!(result.packages, vec!["@scope/pkg1", "@scope/pkg2"]);
+            assert_eq!(result.environments, vec!["staging"]);
+            assert_eq!(result.commit_count, 5);
+            assert_eq!(result.created_at, "2024-01-15T10:00:00Z");
+            assert_eq!(result.updated_at, "2024-01-15T12:00:00Z");
+        }
+
+        #[test]
+        fn test_convert_to_napi_list_data() {
+            let cli_data = CliChangesetListResponseData {
+                success: true,
+                changesets: vec![
+                    CliChangesetListItem {
+                        branch: "feature/a".to_string(),
+                        bump: "patch".to_string(),
+                        packages: vec!["pkg-a".to_string()],
+                        environments: vec![],
+                        commit_count: 1,
+                        created_at: "2024-01-15T10:00:00Z".to_string(),
+                        updated_at: "2024-01-15T10:00:00Z".to_string(),
+                    },
+                    CliChangesetListItem {
+                        branch: "feature/b".to_string(),
+                        bump: "minor".to_string(),
+                        packages: vec!["pkg-b".to_string()],
+                        environments: vec!["prod".to_string()],
+                        commit_count: 2,
+                        created_at: "2024-01-14T09:00:00Z".to_string(),
+                        updated_at: "2024-01-14T09:00:00Z".to_string(),
+                    },
+                ],
+                total: 2,
+            };
+
+            let result = convert_to_napi_list_data(cli_data);
+
+            assert_eq!(result.count, 2);
+            assert_eq!(result.changesets.len(), 2);
+            assert_eq!(result.changesets[0].branch, "feature/a");
+            assert_eq!(result.changesets[1].branch, "feature/b");
+        }
+
+        #[test]
+        fn test_convert_to_napi_list_data_empty() {
+            let cli_data =
+                CliChangesetListResponseData { success: true, changesets: vec![], total: 0 };
+
+            let result = convert_to_napi_list_data(cli_data);
+
+            assert_eq!(result.count, 0);
+            assert!(result.changesets.is_empty());
+        }
+
+        #[test]
+        fn test_convert_list_params_to_args_defaults() {
+            let params = ChangesetListParams::new(".");
+
+            let args = convert_list_params_to_args(&params);
+
+            assert!(args.filter_package.is_none());
+            assert!(args.filter_bump.is_none());
+            assert!(args.filter_env.is_none());
+            assert_eq!(args.sort, "date"); // Default value
+        }
+
+        #[test]
+        fn test_convert_list_params_to_args_with_filters() {
+            let params = ChangesetListParams::new(".")
+                .with_filter_package("@scope/core")
+                .with_filter_bump("major")
+                .with_filter_env("production")
+                .with_sort("branch");
+
+            let args = convert_list_params_to_args(&params);
+
+            assert_eq!(args.filter_package, Some("@scope/core".to_string()));
+            assert_eq!(args.filter_bump, Some("major".to_string()));
+            assert_eq!(args.filter_env, Some("production".to_string()));
+            assert_eq!(args.sort, "branch");
+        }
+
+        #[test]
+        fn test_convert_list_params_to_args_custom_sort() {
+            let params = ChangesetListParams::new(".").with_sort("bump");
+
+            let args = convert_list_params_to_args(&params);
+
+            assert_eq!(args.sort, "bump");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation Tests
+    // -------------------------------------------------------------------------
+
+    mod validation_tests {
+        use super::*;
+        use tempfile::TempDir;
+
+        #[test]
+        fn test_validate_list_params_valid_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetListParams::new(temp_dir.path().to_str().unwrap());
+
+            let result = validate_list_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_list_params_nonexistent_path() {
+            let params = ChangesetListParams::new("/nonexistent/path/that/does/not/exist");
+
+            let result = validate_list_params(&params);
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "ENOENT");
+        }
+
+        #[test]
+        fn test_validate_list_params_empty_root() {
+            let params = ChangesetListParams::new("");
+
+            let result = validate_list_params(&params);
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("empty"));
+        }
+
+        #[test]
+        fn test_validate_list_params_file_not_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let file_path = temp_dir.path().join("test.txt");
+            std::fs::write(&file_path, "test").unwrap();
+
+            let params = ChangesetListParams::new(file_path.to_str().unwrap());
+
+            let result = validate_list_params(&params);
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("directory"));
+        }
+
+        #[test]
+        fn test_validate_list_params_valid_bump_filter() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetListParams::new(temp_dir.path().to_str().unwrap())
+                .with_filter_bump("minor");
+
+            let result = validate_list_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_list_params_invalid_bump_filter() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetListParams::new(temp_dir.path().to_str().unwrap())
+                .with_filter_bump("invalid");
+
+            let result = validate_list_params(&params);
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("invalid bump type"));
+        }
+
+        #[test]
+        fn test_validate_list_params_all_bump_types() {
+            let temp_dir = TempDir::new().unwrap();
+            let root = temp_dir.path().to_str().unwrap();
+
+            for bump in &["major", "minor", "patch", "none"] {
+                let params = ChangesetListParams::new(root).with_filter_bump(*bump);
+                let result = validate_list_params(&params);
+                assert!(result.is_ok(), "Bump type '{bump}' should be valid");
+            }
+        }
+
+        #[test]
+        fn test_validate_list_params_valid_sort_options() {
+            let temp_dir = TempDir::new().unwrap();
+            let root = temp_dir.path().to_str().unwrap();
+
+            for sort in VALID_SORT_OPTIONS {
+                let params = ChangesetListParams::new(root).with_sort(*sort);
+                let result = validate_list_params(&params);
+                assert!(result.is_ok(), "Sort option '{sort}' should be valid");
+            }
+        }
+
+        #[test]
+        fn test_validate_list_params_invalid_sort_option() {
+            let temp_dir = TempDir::new().unwrap();
+            let params =
+                ChangesetListParams::new(temp_dir.path().to_str().unwrap()).with_sort("invalid");
+
+            let result = validate_list_params(&params);
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("invalid sort option"));
+            assert!(error.message.contains("date"));
+            assert!(error.message.contains("branch"));
+            assert!(error.message.contains("bump"));
+        }
+
+        #[test]
+        fn test_validate_list_params_with_all_filters() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetListParams::new(temp_dir.path().to_str().unwrap())
+                .with_filter_package("@scope/core")
+                .with_filter_bump("minor")
+                .with_filter_env("staging")
+                .with_sort("date");
+
+            let result = validate_list_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_list_params_no_sort_uses_default() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetListParams::new(temp_dir.path().to_str().unwrap());
+
+            let result = validate_list_params(&params);
+            assert!(result.is_ok());
+
+            // Verify args conversion uses default
+            let args = convert_list_params_to_args(&params);
+            assert_eq!(args.sort, "date");
+        }
+    }
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -141,7 +141,8 @@ pub use commands::init;
 pub use commands::changeset_add;
 // Story 4.3: changesetUpdate
 pub use commands::changeset_update;
-// TODO: will be implemented on story 4.4 (changesetList)
+// Story 4.4: changesetList
+pub use commands::changeset_list;
 // TODO: will be implemented on story 4.5 (changesetShow)
 // TODO: will be implemented on story 4.6 (changesetRemove)
 // TODO: will be implemented on story 4.7 (changesetHistory)

--- a/crates/node/src/tests.rs
+++ b/crates/node/src/tests.rs
@@ -2451,9 +2451,9 @@ mod changeset_api_response_tests {
     use crate::types::changeset::{
         ChangesetAddApiResponse, ChangesetAddData, ChangesetCheckApiResponse, ChangesetCheckData,
         ChangesetDetailInfo, ChangesetHistoryApiResponse, ChangesetHistoryData,
-        ChangesetListApiResponse, ChangesetListData, ChangesetRemoveApiResponse,
-        ChangesetRemoveData, ChangesetShowApiResponse, ChangesetShowData,
-        ChangesetUpdateApiResponse, ChangesetUpdateData, UpdateSummaryInfo,
+        ChangesetListApiResponse, ChangesetListData, ChangesetListItemInfo,
+        ChangesetRemoveApiResponse, ChangesetRemoveData, ChangesetShowApiResponse,
+        ChangesetShowData, ChangesetUpdateApiResponse, ChangesetUpdateData, UpdateSummaryInfo,
     };
 
     // ========================================================================
@@ -2563,10 +2563,11 @@ mod changeset_api_response_tests {
 
     #[test]
     fn test_changeset_list_api_response_success_with_items() {
-        let changeset = ChangesetDetailInfo::new(
+        let changeset = ChangesetListItemInfo::new(
             "cs-1",
             "feature/one",
             "minor",
+            3, // commit_count
             "2024-01-15T10:00:00Z",
             "2024-01-15T10:00:00Z",
         );
@@ -2576,6 +2577,7 @@ mod changeset_api_response_tests {
         assert!(response.success);
         assert!(response.data.is_some());
         assert_eq!(response.data.as_ref().unwrap().count, 1);
+        assert_eq!(response.data.as_ref().unwrap().changesets[0].commit_count, 3);
     }
 
     #[test]
@@ -2966,8 +2968,9 @@ mod changeset_params_tests {
 mod changeset_data_tests {
     use crate::types::changeset::{
         ArchivedChangesetInfo, ChangesetAddData, ChangesetCheckData, ChangesetDetailInfo,
-        ChangesetHistoryData, ChangesetListData, ChangesetRemoveData, ChangesetShowData,
-        ChangesetUpdateData, ReleaseInfoData, ReleasedVersionEntry, UpdateSummaryInfo,
+        ChangesetHistoryData, ChangesetListData, ChangesetListItemInfo, ChangesetRemoveData,
+        ChangesetShowData, ChangesetUpdateData, ReleaseInfoData, ReleasedVersionEntry,
+        UpdateSummaryInfo,
     };
 
     // ========================================================================
@@ -3226,17 +3229,19 @@ mod changeset_data_tests {
     #[test]
     fn test_changeset_list_data_new() {
         let changesets = vec![
-            ChangesetDetailInfo::new(
+            ChangesetListItemInfo::new(
                 "cs-1",
                 "branch-1",
                 "minor",
+                3, // commit_count
                 "2024-01-15T10:00:00Z",
                 "2024-01-15T10:00:00Z",
             ),
-            ChangesetDetailInfo::new(
+            ChangesetListItemInfo::new(
                 "cs-2",
                 "branch-2",
                 "patch",
+                1, // commit_count
                 "2024-01-14T10:00:00Z",
                 "2024-01-14T10:00:00Z",
             ),
@@ -3245,6 +3250,8 @@ mod changeset_data_tests {
 
         assert_eq!(data.count, 2);
         assert_eq!(data.changesets.len(), 2);
+        assert_eq!(data.changesets[0].commit_count, 3);
+        assert_eq!(data.changesets[1].commit_count, 1);
     }
 
     #[test]

--- a/crates/node/src/types/changeset.rs
+++ b/crates/node/src/types/changeset.rs
@@ -1631,16 +1631,169 @@ impl ChangesetUpdateData {
     }
 }
 
+/// Changeset information for list responses.
+///
+/// This type is specifically designed for the changeset list command output,
+/// which returns `commit_count` rather than individual commit hashes. For
+/// full commit details, use `ChangesetDetailInfo` via the `changesetShow` command.
+///
+/// # Fields
+///
+/// - `id`: Unique changeset identifier (derived from branch)
+/// - `branch`: Git branch name
+/// - `bump`: Version bump type (major, minor, patch, none)
+/// - `packages`: List of affected packages
+/// - `environments`: Target environments
+/// - `commit_count`: Number of commits in the changeset
+/// - `created_at`: Creation timestamp (ISO 8601)
+/// - `updated_at`: Last update timestamp (ISO 8601)
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface ChangesetListItemInfo {
+///   id: string;
+///   branch: string;
+///   bump: string;
+///   packages: string[];
+///   environments: string[];
+///   commitCount: number;
+///   createdAt: string;
+///   updatedAt: string;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// const result = await changesetList({ root: '.' });
+/// if (result.success) {
+///   for (const item of result.data.changesets) {
+///     console.log(`${item.branch}: ${item.bump} (${item.commitCount} commits)`);
+///   }
+/// }
+/// ```
+#[allow(dead_code)]
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct ChangesetListItemInfo {
+    /// Unique changeset identifier.
+    ///
+    /// This ID is derived from the branch name and uniquely identifies
+    /// the changeset within the workspace.
+    pub id: String,
+
+    /// Git branch name.
+    ///
+    /// The full branch name associated with this changeset.
+    pub branch: String,
+
+    /// Version bump type.
+    ///
+    /// One of: `"major"`, `"minor"`, `"patch"`, `"none"`.
+    pub bump: String,
+
+    /// List of affected packages.
+    ///
+    /// Package names exactly as defined in each package's `package.json`.
+    pub packages: Vec<String>,
+
+    /// Target environments.
+    ///
+    /// List of environments this changeset applies to.
+    pub environments: Vec<String>,
+
+    /// Number of commits in the changeset.
+    ///
+    /// The count of git commits associated with this changeset.
+    /// For full commit details, use `changesetShow`.
+    pub commit_count: u32,
+
+    /// Creation timestamp (ISO 8601 format).
+    ///
+    /// When the changeset was first created.
+    /// Example: `"2024-01-15T10:30:00Z"`
+    pub created_at: String,
+
+    /// Last update timestamp (ISO 8601 format).
+    ///
+    /// When the changeset was last modified.
+    /// Example: `"2024-01-15T14:45:00Z"`
+    pub updated_at: String,
+}
+
+#[allow(dead_code)]
+impl ChangesetListItemInfo {
+    /// Creates a new `ChangesetListItemInfo` with all required fields.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Unique changeset identifier
+    /// * `branch` - Git branch name
+    /// * `bump` - Version bump type
+    /// * `commit_count` - Number of commits
+    /// * `created_at` - Creation timestamp
+    /// * `updated_at` - Last update timestamp
+    #[must_use]
+    pub fn new(
+        id: impl Into<String>,
+        branch: impl Into<String>,
+        bump: impl Into<String>,
+        commit_count: u32,
+        created_at: impl Into<String>,
+        updated_at: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            branch: branch.into(),
+            bump: bump.into(),
+            packages: Vec::new(),
+            environments: Vec::new(),
+            commit_count,
+            created_at: created_at.into(),
+            updated_at: updated_at.into(),
+        }
+    }
+
+    /// Sets the packages list.
+    #[must_use]
+    pub fn with_packages(mut self, packages: Vec<String>) -> Self {
+        self.packages = packages;
+        self
+    }
+
+    /// Sets the environments list.
+    #[must_use]
+    pub fn with_environments(mut self, environments: Vec<String>) -> Self {
+        self.environments = environments;
+        self
+    }
+}
+
 /// Response data for the changeset list command.
 ///
-/// Contains the list of pending changesets.
+/// Contains the list of pending changesets with summary information.
+/// Each changeset item includes `commit_count` rather than full commit
+/// details - use `changesetShow` for complete commit information.
 ///
 /// # TypeScript Definition
 ///
 /// ```typescript
 /// interface ChangesetListData {
-///   changesets: ChangesetDetailInfo[];
+///   changesets: ChangesetListItemInfo[];
 ///   count: number;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// const result = await changesetList({ root: '.' });
+/// if (result.success) {
+///   console.log(`Found ${result.data.count} changesets`);
+///   for (const cs of result.data.changesets) {
+///     console.log(`- ${cs.branch}: ${cs.bump} (${cs.commitCount} commits)`);
+///   }
 /// }
 /// ```
 #[allow(dead_code)]
@@ -1648,7 +1801,9 @@ impl ChangesetUpdateData {
 #[derive(Debug, Clone, Serialize)]
 pub struct ChangesetListData {
     /// List of pending changesets.
-    pub changesets: Vec<ChangesetDetailInfo>,
+    ///
+    /// Each item contains summary information including commit count.
+    pub changesets: Vec<ChangesetListItemInfo>,
 
     /// Total count of changesets.
     pub count: u32,
@@ -1658,7 +1813,7 @@ pub struct ChangesetListData {
 impl ChangesetListData {
     /// Creates a new `ChangesetListData`.
     #[must_use]
-    pub fn new(changesets: Vec<ChangesetDetailInfo>) -> Self {
+    pub fn new(changesets: Vec<ChangesetListItemInfo>) -> Self {
         // Saturating conversion is safe here - we won't have more than u32::MAX changesets
         #[allow(clippy::cast_possible_truncation)]
         let count = changesets.len() as u32;

--- a/packages/workspace-tools/npm/darwin-arm64/package.json
+++ b/packages/workspace-tools/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-arm64",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/darwin-x64/package.json
+++ b/packages/workspace-tools/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-x64",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-gnu",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-musl",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-gnu",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-musl",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/win32-arm64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-arm64-msvc",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/win32-x64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-x64-msvc",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Bindings for node from crate workspace-tools",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/types/index.d.cts",

--- a/packages/workspace-tools/src/binding.d.ts
+++ b/packages/workspace-tools/src/binding.d.ts
@@ -699,6 +699,107 @@ export interface ChangesetInfo {
 }
 
 /**
+ * List all pending changesets in the workspace.
+ *
+ * Retrieves all pending (not yet released) changesets with optional filtering
+ * by package, bump type, or environment. Results can be sorted by date, branch
+ * name, or bump type.
+ *
+ * @param params - Changeset list parameters containing:
+ *   - `root`: Workspace root directory path (required)
+ *   - `configPath`: Optional custom config file path
+ *   - `filterPackage`: Optional filter by package name
+ *   - `filterBump`: Optional filter by bump type (major, minor, patch)
+ *   - `filterEnv`: Optional filter by environment
+ *   - `sort`: Sort order (date, branch, bump). Defaults to "date"
+ *
+ * @returns `Promise<ChangesetListApiResponse>` containing:
+ *   - On success: `{ success: true, data: ChangesetListData }`
+ *   - On failure: `{ success: false, error: ErrorInfo }`
+ *
+ * @example List all changesets
+ * ```typescript
+ * const result = await changesetList({
+ *   root: '/path/to/workspace'
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Found ${result.data.count} changeset(s)`);
+ *   for (const cs of result.data.changesets) {
+ *     console.log(`- ${cs.branch}: ${cs.bump}`);
+ *   }
+ * }
+ * ```
+ *
+ * @example Filter by bump type
+ * ```typescript
+ * const result = await changesetList({
+ *   root: '/path/to/workspace',
+ *   filterBump: 'major'
+ * });
+ *
+ * if (result.success) {
+ *   console.log('Major version changesets:');
+ *   result.data.changesets.forEach(cs => {
+ *     console.log(`  ${cs.branch}: ${cs.packages.join(', ')}`);
+ *   });
+ * }
+ * ```
+ *
+ * @example Filter by package
+ * ```typescript
+ * const result = await changesetList({
+ *   root: '/path/to/workspace',
+ *   filterPackage: '@scope/core'
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Changesets affecting @scope/core: ${result.data.count}`);
+ * }
+ * ```
+ *
+ * @example Sort by branch name
+ * ```typescript
+ * const result = await changesetList({
+ *   root: '/path/to/workspace',
+ *   sort: 'branch'
+ * });
+ * ```
+ *
+ * @example Filter by environment
+ * ```typescript
+ * const result = await changesetList({
+ *   root: '/path/to/workspace',
+ *   filterEnv: 'production'
+ * });
+ * ```
+ *
+ * @example Error handling
+ * ```typescript
+ * const result = await changesetList({
+ *   root: '/nonexistent/path'
+ * });
+ *
+ * if (!result.success) {
+ *   switch (result.error.code) {
+ *     case 'ENOENT':
+ *       console.error('Path not found');
+ *       break;
+ *     case 'EVALIDATION':
+ *       console.error('Invalid parameters:', result.error.message);
+ *       break;
+ *     case 'ECONFIG':
+ *       console.error('Workspace not initialized');
+ *       break;
+ *     default:
+ *       console.error(`Error: ${result.error.message}`);
+ *   }
+ * }
+ * ```
+ */
+export declare function changesetList(params: ChangesetListParams): Promise<ChangesetListApiResponse>
+
+/**
  * API response for the changeset list command.
  *
  * Wraps `ChangesetListData` with success/error handling.
@@ -725,22 +826,139 @@ export interface ChangesetListApiResponse {
 /**
  * Response data for the changeset list command.
  *
- * Contains the list of pending changesets.
+ * Contains the list of pending changesets with summary information.
+ * Each changeset item includes `commit_count` rather than full commit
+ * details - use `changesetShow` for complete commit information.
  *
  * # TypeScript Definition
  *
  * ```typescript
  * interface ChangesetListData {
- *   changesets: ChangesetDetailInfo[];
+ *   changesets: ChangesetListItemInfo[];
  *   count: number;
+ * }
+ * ```
+ *
+ * # Examples
+ *
+ * ```typescript
+ * const result = await changesetList({ root: '.' });
+ * if (result.success) {
+ *   console.log(`Found ${result.data.count} changesets`);
+ *   for (const cs of result.data.changesets) {
+ *     console.log(`- ${cs.branch}: ${cs.bump} (${cs.commitCount} commits)`);
+ *   }
  * }
  * ```
  */
 export interface ChangesetListData {
-  /** List of pending changesets. */
-  changesets: Array<ChangesetDetailInfo>
+  /**
+   * List of pending changesets.
+   *
+   * Each item contains summary information including commit count.
+   */
+  changesets: Array<ChangesetListItemInfo>
   /** Total count of changesets. */
   count: number
+}
+
+/**
+ * Changeset information for list responses.
+ *
+ * This type is specifically designed for the changeset list command output,
+ * which returns `commit_count` rather than individual commit hashes. For
+ * full commit details, use `ChangesetDetailInfo` via the `changesetShow` command.
+ *
+ * # Fields
+ *
+ * - `id`: Unique changeset identifier (derived from branch)
+ * - `branch`: Git branch name
+ * - `bump`: Version bump type (major, minor, patch, none)
+ * - `packages`: List of affected packages
+ * - `environments`: Target environments
+ * - `commit_count`: Number of commits in the changeset
+ * - `created_at`: Creation timestamp (ISO 8601)
+ * - `updated_at`: Last update timestamp (ISO 8601)
+ *
+ * # TypeScript Definition
+ *
+ * ```typescript
+ * interface ChangesetListItemInfo {
+ *   id: string;
+ *   branch: string;
+ *   bump: string;
+ *   packages: string[];
+ *   environments: string[];
+ *   commitCount: number;
+ *   createdAt: string;
+ *   updatedAt: string;
+ * }
+ * ```
+ *
+ * # Examples
+ *
+ * ```typescript
+ * const result = await changesetList({ root: '.' });
+ * if (result.success) {
+ *   for (const item of result.data.changesets) {
+ *     console.log(`${item.branch}: ${item.bump} (${item.commitCount} commits)`);
+ *   }
+ * }
+ * ```
+ */
+export interface ChangesetListItemInfo {
+  /**
+   * Unique changeset identifier.
+   *
+   * This ID is derived from the branch name and uniquely identifies
+   * the changeset within the workspace.
+   */
+  id: string
+  /**
+   * Git branch name.
+   *
+   * The full branch name associated with this changeset.
+   */
+  branch: string
+  /**
+   * Version bump type.
+   *
+   * One of: `"major"`, `"minor"`, `"patch"`, `"none"`.
+   */
+  bump: string
+  /**
+   * List of affected packages.
+   *
+   * Package names exactly as defined in each package's `package.json`.
+   */
+  packages: Array<string>
+  /**
+   * Target environments.
+   *
+   * List of environments this changeset applies to.
+   */
+  environments: Array<string>
+  /**
+   * Number of commits in the changeset.
+   *
+   * The count of git commits associated with this changeset.
+   * For full commit details, use `changesetShow`.
+   */
+  commitCount: number
+  /**
+   * Creation timestamp (ISO 8601 format).
+   *
+   * When the changeset was first created.
+   * Example: `"2024-01-15T10:30:00Z"`
+   */
+  createdAt: string
+  /**
+   * Last update timestamp (ISO 8601 format).
+   *
+   * When the changeset was last modified.
+   * Example: `"2024-01-15T14:45:00Z"`
+   */
+  updatedAt: string
 }
 
 /**

--- a/packages/workspace-tools/src/binding.js
+++ b/packages/workspace-tools/src/binding.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm-eabi')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-ia32-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-arm64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@websublime/workspace-tools-darwin-universal')
       const bindingPackageVersion = require('@websublime/workspace-tools-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-musleabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-ppc64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-s390x-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.0.4' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.4 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.5' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.5 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -573,6 +573,7 @@ if (!nativeBinding) {
 
 module.exports = nativeBinding
 module.exports.changesetAdd = nativeBinding.changesetAdd
+module.exports.changesetList = nativeBinding.changesetList
 module.exports.changesetUpdate = nativeBinding.changesetUpdate
 module.exports.getVersion = nativeBinding.getVersion
 module.exports.init = nativeBinding.init

--- a/packages/workspace-tools/src/index.ts
+++ b/packages/workspace-tools/src/index.ts
@@ -12,7 +12,8 @@
  * - `init()` - Initialize workspace with changeset-based version management
  * - `changesetAdd()` - Add a new changeset to the workspace (Story 4.2)
  * - `changesetUpdate()` - Update an existing changeset (Story 4.3)
- * - Changeset types for upcoming changeset commands (Stories 4.4-4.8)
+ * - `changesetList()` - List pending changesets with filtering (Story 4.4)
+ * - Changeset types for upcoming changeset commands (Stories 4.5-4.8)
  *
  * ## How
  *
@@ -32,9 +33,9 @@
  */
 
 // Re-export all functions from bindings
-import { changesetAdd, changesetUpdate, getVersion, init, status } from './binding'
+import { changesetAdd, changesetList, changesetUpdate, getVersion, init, status } from './binding'
 
-export { changesetAdd, changesetUpdate, getVersion, init, status }
+export { changesetAdd, changesetList, changesetUpdate, getVersion, init, status }
 
 // Re-export all types from bindings
 export type {
@@ -88,6 +89,7 @@ export type {
 
   // Supporting types
   ChangesetDetailInfo,
+  ChangesetListItemInfo,
   UpdateSummaryInfo,
   ArchivedChangesetInfo,
   ReleaseInfoData,


### PR DESCRIPTION
- Add changeset_list function to list pending changesets with filtering
- Create ChangesetListItemInfo type with commit_count instead of empty commits array
- Support filtering by package, bump type, and environment
- Support sorting by date, branch, or bump type
- Add validation for sort options and bump type filters
- Add 39 comprehensive tests for list functionality
- Update ChangesetListData to use ChangesetListItemInfo
- Export changesetList and ChangesetListItemInfo in TypeScript bindings
- Regenerate bindings in release mode

Story 4.4: Implement changesetList