### PR TITLE
feat(WOR-TSK-187): implement changesetRemove NAPI function

### DIFF
--- a/crates/node/src/commands/changeset.rs
+++ b/crates/node/src/commands/changeset.rs
@@ -102,16 +102,18 @@ use crate::error::ErrorInfo;
 use crate::types::changeset::{
     ChangesetAddApiResponse, ChangesetAddData, ChangesetAddParams, ChangesetDetailInfo,
     ChangesetListApiResponse, ChangesetListData, ChangesetListItemInfo, ChangesetListParams,
+    ChangesetRemoveApiResponse, ChangesetRemoveData, ChangesetRemoveParams,
     ChangesetShowApiResponse, ChangesetShowData, ChangesetShowParams, ChangesetUpdateApiResponse,
     ChangesetUpdateData, ChangesetUpdateParams, UpdateSummaryInfo, VALID_SORT_OPTIONS,
 };
 use crate::validation::validators;
 
 use sublime_cli_tools::cli::commands::{
-    ChangesetCreateArgs, ChangesetListArgs, ChangesetShowArgs, ChangesetUpdateArgs,
+    ChangesetCreateArgs, ChangesetDeleteArgs, ChangesetListArgs, ChangesetShowArgs,
+    ChangesetUpdateArgs,
 };
 use sublime_cli_tools::commands::changeset::{
-    execute_add, execute_list, execute_show, execute_update,
+    execute_add, execute_list, execute_remove, execute_show, execute_update,
 };
 use sublime_cli_tools::output::{Output, OutputFormat};
 
@@ -1621,6 +1623,362 @@ pub async fn changeset_show(params: ChangesetShowParams) -> ChangesetShowApiResp
         Ok(Ok(data)) => ChangesetShowApiResponse::success(data),
         Ok(Err(error)) => ChangesetShowApiResponse::failure(error),
         Err(join_error) => ChangesetShowApiResponse::failure(ErrorInfo::execution(format!(
+            "Task execution failed: {join_error}"
+        ))),
+    }
+}
+
+// ============================================================================
+// Changeset Remove - CLI Response Types
+// ============================================================================
+
+/// CLI changeset remove response data structure.
+///
+/// Mirrors the `ChangesetRemoveResponse` structure from the CLI's changeset remove command.
+/// Used for deserializing the JSON output captured from the CLI.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliChangesetRemoveResponseData {
+    /// Whether the operation succeeded.
+    #[serde(default)]
+    pub(crate) success: bool,
+    /// The branch name that was removed.
+    pub(crate) branch: String,
+    /// Whether the changeset was archived before removal.
+    #[serde(default)]
+    pub(crate) archived: bool,
+    /// Details of the removed changeset.
+    pub(crate) changeset: CliRemovedChangesetInfo,
+}
+
+/// CLI removed changeset info structure.
+///
+/// Contains details about the changeset that was removed.
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliRemovedChangesetInfo {
+    /// Branch name (also serves as unique identifier).
+    pub(crate) branch: String,
+    /// Version bump type.
+    pub(crate) bump: String,
+    /// List of affected packages.
+    #[serde(default)]
+    pub(crate) packages: Vec<String>,
+    /// Target environments.
+    #[serde(default)]
+    pub(crate) environments: Vec<String>,
+    /// Number of commits.
+    #[serde(default)]
+    pub(crate) commit_count: usize,
+}
+
+// ============================================================================
+// Changeset Remove - Conversion Functions
+// ============================================================================
+
+/// Converts CLI remove response data to NAPI `ChangesetRemoveData`.
+///
+/// This function transforms the deserialized CLI response into the
+/// NAPI-compatible `ChangesetRemoveData` structure.
+///
+/// # Arguments
+///
+/// * `cli_data` - The CLI response data from the changeset remove command
+///
+/// # Returns
+///
+/// A `ChangesetRemoveData` instance with the converted data.
+pub(crate) fn convert_to_napi_remove_data(
+    cli_data: &CliChangesetRemoveResponseData,
+) -> ChangesetRemoveData {
+    ChangesetRemoveData::new(true, &cli_data.branch)
+}
+
+/// Parses the JSON bytes from CLI output into `ChangesetRemoveData`.
+///
+/// This function handles:
+/// - Empty or whitespace-only output
+/// - Invalid UTF-8 encoding
+/// - Invalid JSON format
+/// - CLI error responses
+/// - Successful responses with data
+///
+/// # Arguments
+///
+/// * `json_bytes` - Raw bytes captured from CLI output
+///
+/// # Returns
+///
+/// * `Ok(ChangesetRemoveData)` - Successfully parsed response
+/// * `Err(ErrorInfo)` - Error details if parsing failed
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The output is empty
+/// - The output is not valid UTF-8
+/// - The output is not valid JSON
+/// - The CLI returned an error response
+/// - The success response has no data
+pub(crate) fn parse_changeset_remove_response(
+    json_bytes: &[u8],
+) -> Result<ChangesetRemoveData, ErrorInfo> {
+    // Check for empty output
+    let json_str = match String::from_utf8(json_bytes.to_vec()) {
+        Ok(s) if s.trim().is_empty() => {
+            return Err(ErrorInfo::execution("CLI returned empty output"));
+        }
+        Ok(s) => s,
+        Err(e) => {
+            return Err(ErrorInfo::execution(format!("Invalid UTF-8 in CLI output: {e}")));
+        }
+    };
+
+    // Parse JSON
+    let response: CliJsonResponse<CliChangesetRemoveResponseData> = serde_json::from_str(&json_str)
+        .map_err(|e| ErrorInfo::execution(format!("Failed to parse CLI JSON response: {e}")))?;
+
+    // Check for CLI error
+    if !response.success {
+        let error_message = response.error.unwrap_or_else(|| "Unknown CLI error".to_string());
+        return Err(ErrorInfo::execution(error_message));
+    }
+
+    // Extract data
+    match response.data {
+        Some(data) => Ok(convert_to_napi_remove_data(&data)),
+        None => Err(ErrorInfo::execution("CLI returned success but no data")),
+    }
+}
+
+// ============================================================================
+// Changeset Remove - Validation
+// ============================================================================
+
+/// Validates the parameters for the changeset remove command.
+///
+/// Performs the following validations:
+/// - Root path exists and is a directory
+/// - Branch parameter is not empty
+///
+/// # Arguments
+///
+/// * `params` - The changeset remove parameters to validate
+///
+/// # Returns
+///
+/// * `Ok(PathBuf)` - The validated root path as a `PathBuf`
+/// * `Err(ErrorInfo)` - Validation error with details
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The root path is empty, doesn't exist, or is not a directory
+/// - The branch parameter is empty
+pub(crate) fn validate_remove_params(params: &ChangesetRemoveParams) -> Result<PathBuf, ErrorInfo> {
+    // Validate root path exists and is a directory
+    validators::root(&params.root)?;
+
+    // Validate branch is not empty
+    if params.branch.trim().is_empty() {
+        return Err(ErrorInfo::validation(
+            "branch parameter is required and cannot be empty",
+            Some("branch"),
+        ));
+    }
+
+    Ok(PathBuf::from(&params.root))
+}
+
+/// Converts NAPI parameters to CLI arguments.
+///
+/// This function transforms the NAPI-friendly `ChangesetRemoveParams` into the
+/// CLI's `ChangesetDeleteArgs` structure.
+///
+/// **Note**: The `force` flag is always set to `true` in the API layer because
+/// there is no interactive confirmation prompt available in programmatic usage.
+/// The caller is expected to handle confirmation in their own application if needed.
+///
+/// # Arguments
+///
+/// * `params` - The NAPI changeset remove parameters
+///
+/// # Returns
+///
+/// A `ChangesetDeleteArgs` instance ready for CLI execution.
+pub(crate) fn convert_remove_params_to_args(params: &ChangesetRemoveParams) -> ChangesetDeleteArgs {
+    ChangesetDeleteArgs {
+        branch: params.branch.clone(),
+        // Always force in API mode - no interactive prompts available
+        force: true,
+    }
+}
+
+// ============================================================================
+// Changeset Remove - NAPI Function
+// ============================================================================
+
+/// Remove a changeset from the workspace.
+///
+/// Deletes a changeset identified by its branch name. The changeset is archived
+/// before deletion for recovery purposes. In API mode, the operation always
+/// proceeds without confirmation (equivalent to `--force` flag in CLI).
+///
+/// @param params - Changeset remove parameters containing:
+///   - `root`: Workspace root directory path (required)
+///   - `configPath`: Optional custom config file path
+///   - `branch`: Branch name or changeset ID to remove (required)
+///   - `force`: Ignored in API mode (always treated as true)
+///
+/// @returns `Promise<ChangesetRemoveApiResponse>` - Response containing:
+///   - `success`: Whether the operation succeeded
+///   - `data`: Removal confirmation if successful
+///   - `error`: Error information if failed
+///
+/// ## Success Response
+///
+/// When successful, `data` contains:
+/// - `removed`: Boolean indicating the changeset was removed (always true on success)
+/// - `branch`: The branch name that was removed
+///
+/// ## Behavior Notes
+///
+/// - The changeset is archived before deletion for potential recovery
+/// - The archive includes a marker indicating manual deletion (not a release)
+/// - In API mode, no confirmation prompt is shown (force mode is implicit)
+///
+/// ## Error Codes
+///
+/// - `EVALIDATION`: Invalid parameters (empty root or branch)
+/// - `ENOENT`: Path or changeset not found
+/// - `ECONFIG`: Workspace not initialized
+/// - `EEXECUTION`: CLI command failed
+///
+/// @example Basic usage
+/// ```typescript
+/// const result = await changesetRemove({
+///   root: '/path/to/workspace',
+///   branch: 'feature/abandoned-work'
+/// });
+///
+/// if (result.success) {
+///   console.log(`Removed changeset: ${result.data.branch}`);
+/// } else {
+///   console.error(`Error: ${result.error.message}`);
+/// }
+/// ```
+///
+/// @example With custom config
+/// ```typescript
+/// const result = await changesetRemove({
+///   root: '/path/to/workspace',
+///   configPath: '/path/to/custom.config.json',
+///   branch: 'feature/obsolete'
+/// });
+/// ```
+///
+/// @example Error handling
+/// ```typescript
+/// const result = await changesetRemove({
+///   root: '/path/to/workspace',
+///   branch: 'nonexistent-branch'
+/// });
+///
+/// if (!result.success) {
+///   switch (result.error.code) {
+///     case 'ENOENT':
+///       console.error('Changeset not found');
+///       break;
+///     case 'EVALIDATION':
+///       console.error('Invalid parameters:', result.error.message);
+///       break;
+///     case 'ECONFIG':
+///       console.error('Workspace not initialized');
+///       break;
+///     default:
+///       console.error(`Error: ${result.error.message}`);
+///   }
+/// }
+/// ```
+///
+/// @example Cleanup workflow
+/// ```typescript
+/// // List all changesets, then remove stale ones
+/// const listResult = await changesetList({ root: '.' });
+///
+/// if (listResult.success) {
+///   for (const changeset of listResult.data.changesets) {
+///     // Check if changeset is older than 30 days
+///     const createdAt = new Date(changeset.createdAt);
+///     const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+///
+///     if (createdAt < thirtyDaysAgo) {
+///       const removeResult = await changesetRemove({
+///         root: '.',
+///         branch: changeset.branch
+///       });
+///
+///       if (removeResult.success) {
+///         console.log(`Removed stale changeset: ${changeset.branch}`);
+///       }
+///     }
+///   }
+/// }
+/// ```
+#[napi(js_name = "changesetRemove")]
+pub async fn changeset_remove(params: ChangesetRemoveParams) -> ChangesetRemoveApiResponse {
+    // 1. Validate parameters (synchronous validation before spawning)
+    let root_path = match validate_remove_params(&params) {
+        Ok(path) => path,
+        Err(error) => return ChangesetRemoveApiResponse::failure(error),
+    };
+
+    // 2. Prepare config path
+    let config_path: Option<PathBuf> = params.config_path.as_ref().map(PathBuf::from);
+
+    // 3. Convert NAPI params to CLI args
+    let args = convert_remove_params_to_args(&params);
+
+    // 4. Execute CLI command in a blocking task
+    // The CLI's execute_remove uses types that are not Send/Sync (RefCell, git2::Repository),
+    // so we must run it on a blocking thread via spawn_blocking.
+    let result = tokio::task::spawn_blocking(move || {
+        // Create a new tokio runtime for the blocking context
+        // This is necessary because execute_remove is async but we're in a blocking context
+        let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                return Err(ErrorInfo::execution(format!("Failed to create runtime: {e}")));
+            }
+        };
+
+        rt.block_on(async {
+            // Create shared buffer for output capture
+            let buffer = SharedBuffer::new();
+
+            // Create Output with JSON format
+            let output = Output::new(OutputFormat::Json, buffer.clone(), true);
+
+            // Execute the CLI command
+            if let Err(cli_error) =
+                execute_remove(&args, &output, Some(root_path.as_path()), config_path.as_deref())
+                    .await
+            {
+                return Err(ErrorInfo::from(cli_error));
+            }
+
+            // Extract and parse JSON
+            let json_bytes = buffer.take_bytes();
+            parse_changeset_remove_response(&json_bytes)
+        })
+    })
+    .await;
+
+    // 5. Handle spawn_blocking result
+    match result {
+        Ok(Ok(data)) => ChangesetRemoveApiResponse::success(data),
+        Ok(Err(error)) => ChangesetRemoveApiResponse::failure(error),
+        Err(join_error) => ChangesetRemoveApiResponse::failure(ErrorInfo::execution(format!(
             "Task execution failed: {join_error}"
         ))),
     }

--- a/crates/node/src/commands/mod.rs
+++ b/crates/node/src/commands/mod.rs
@@ -74,7 +74,8 @@ pub use changeset::changeset_update;
 pub use changeset::changeset_list;
 // Story 4.5: changesetShow
 pub use changeset::changeset_show;
-// TODO: will be implemented on story 4.6 (changesetRemove)
+// Story 4.6: changesetRemove
+pub use changeset::changeset_remove;
 // TODO: will be implemented on story 4.7 (changesetHistory)
 // TODO: will be implemented on story 4.8 (changesetCheck)
 

--- a/crates/node/src/commands/tests.rs
+++ b/crates/node/src/commands/tests.rs
@@ -2792,3 +2792,424 @@ mod changeset_show_tests {
         }
     }
 }
+
+// ============================================================================
+// Changeset Remove Command Tests (Story 4.6)
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod changeset_remove_tests {
+    use std::io::Write;
+
+    use tempfile::TempDir;
+
+    use crate::commands::changeset::{
+        CliChangesetRemoveResponseData, CliRemovedChangesetInfo, SharedBuffer,
+        convert_remove_params_to_args, convert_to_napi_remove_data,
+        parse_changeset_remove_response, validate_remove_params,
+    };
+    use crate::types::changeset::ChangesetRemoveParams;
+
+    // -------------------------------------------------------------------------
+    // SharedBuffer Tests
+    // -------------------------------------------------------------------------
+
+    mod shared_buffer_tests {
+        use super::*;
+
+        #[test]
+        fn test_shared_buffer_new() {
+            let buffer = SharedBuffer::new();
+            assert!(buffer.take_bytes().is_empty());
+        }
+
+        #[test]
+        fn test_shared_buffer_write() {
+            let mut buffer = SharedBuffer::new();
+            let bytes_written = buffer.write(b"hello").unwrap();
+            assert_eq!(bytes_written, 5);
+            assert_eq!(buffer.take_bytes(), b"hello");
+        }
+
+        #[test]
+        fn test_shared_buffer_multiple_writes() {
+            let mut buffer = SharedBuffer::new();
+            buffer.write_all(b"hello ").unwrap();
+            buffer.write_all(b"world").unwrap();
+            assert_eq!(buffer.take_bytes(), b"hello world");
+        }
+
+        #[test]
+        fn test_shared_buffer_clone_shares_data() {
+            let mut buffer = SharedBuffer::new();
+            let buffer_clone = buffer.clone();
+            buffer.write_all(b"test data").unwrap();
+
+            // Both should see the same data
+            assert_eq!(buffer.take_bytes(), b"test data");
+            assert_eq!(buffer_clone.take_bytes(), b"test data");
+        }
+
+        #[test]
+        fn test_shared_buffer_flush() {
+            let mut buffer = SharedBuffer::new();
+            assert!(buffer.flush().is_ok());
+        }
+
+        #[test]
+        fn test_shared_buffer_take_bytes_preserves_data() {
+            let mut buffer = SharedBuffer::new();
+            buffer.write_all(b"preserved").unwrap();
+
+            let first = buffer.take_bytes();
+            let second = buffer.take_bytes();
+
+            assert_eq!(first, second);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Parse Response Tests
+    // -------------------------------------------------------------------------
+
+    mod parse_response_tests {
+        use super::*;
+
+        #[test]
+        fn test_parse_changeset_remove_response_success() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "success": true,
+                    "branch": "feature/test",
+                    "archived": true,
+                    "changeset": {
+                        "branch": "feature/test",
+                        "bump": "minor",
+                        "packages": ["@scope/pkg1", "@scope/pkg2"],
+                        "environments": ["development", "production"],
+                        "commit_count": 5
+                    }
+                }
+            }"#;
+
+            let result = parse_changeset_remove_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            assert!(data.removed);
+            assert_eq!(data.branch, "feature/test");
+        }
+
+        #[test]
+        fn test_parse_changeset_remove_response_minimal() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "success": true,
+                    "branch": "fix/bug",
+                    "archived": false,
+                    "changeset": {
+                        "branch": "fix/bug",
+                        "bump": "patch",
+                        "packages": [],
+                        "environments": [],
+                        "commit_count": 0
+                    }
+                }
+            }"#;
+
+            let result = parse_changeset_remove_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            assert!(data.removed);
+            assert_eq!(data.branch, "fix/bug");
+        }
+
+        #[test]
+        fn test_parse_changeset_remove_response_cli_error() {
+            let json = r#"{
+                "success": false,
+                "error": "Changeset not found: nonexistent"
+            }"#;
+
+            let result = parse_changeset_remove_response(json.as_bytes());
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Changeset not found"));
+        }
+
+        #[test]
+        fn test_parse_changeset_remove_response_empty() {
+            let result = parse_changeset_remove_response(b"");
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("empty"));
+        }
+
+        #[test]
+        fn test_parse_changeset_remove_response_whitespace_only() {
+            let result = parse_changeset_remove_response(b"   \n\t  ");
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("empty"));
+        }
+
+        #[test]
+        fn test_parse_changeset_remove_response_invalid_json() {
+            let result = parse_changeset_remove_response(b"not valid json");
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("parse"));
+        }
+
+        #[test]
+        fn test_parse_changeset_remove_response_invalid_utf8() {
+            let invalid_utf8 = vec![0xff, 0xfe, 0x00, 0x01];
+            let result = parse_changeset_remove_response(&invalid_utf8);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("UTF-8"));
+        }
+
+        #[test]
+        fn test_parse_changeset_remove_response_success_no_data() {
+            let json = r#"{"success": true}"#;
+            let result = parse_changeset_remove_response(json.as_bytes());
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("no data"));
+        }
+
+        #[test]
+        fn test_parse_changeset_remove_response_cli_error_no_message() {
+            let json = r#"{"success": false}"#;
+            let result = parse_changeset_remove_response(json.as_bytes());
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("Unknown CLI error"));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Conversion Tests
+    // -------------------------------------------------------------------------
+
+    mod conversion_tests {
+        use super::*;
+
+        #[test]
+        fn test_convert_to_napi_remove_data() {
+            let cli_data = CliChangesetRemoveResponseData {
+                success: true,
+                branch: "feature/test".to_string(),
+                archived: true,
+                changeset: CliRemovedChangesetInfo {
+                    branch: "feature/test".to_string(),
+                    bump: "minor".to_string(),
+                    packages: vec!["@scope/pkg1".to_string()],
+                    environments: vec!["production".to_string()],
+                    commit_count: 3,
+                },
+            };
+
+            let result = convert_to_napi_remove_data(&cli_data);
+
+            assert!(result.removed);
+            assert_eq!(result.branch, "feature/test");
+        }
+
+        #[test]
+        fn test_convert_remove_params_to_args_basic() {
+            let params = ChangesetRemoveParams::new(".", "feature/test");
+
+            let args = convert_remove_params_to_args(&params);
+
+            assert_eq!(args.branch, "feature/test");
+            // Force is always true in API mode
+            assert!(args.force);
+        }
+
+        #[test]
+        fn test_convert_remove_params_to_args_force_ignored() {
+            // Even if force is explicitly set to false, it should be true in API mode
+            let params = ChangesetRemoveParams {
+                root: ".".to_string(),
+                config_path: None,
+                branch: "feature/test".to_string(),
+                force: Some(false),
+            };
+
+            let args = convert_remove_params_to_args(&params);
+
+            // Force is always true in API mode - no interactive prompts
+            assert!(args.force);
+        }
+
+        #[test]
+        fn test_convert_remove_params_to_args_various_branches() {
+            // Simple branch
+            let params = ChangesetRemoveParams::new(".", "main");
+            assert_eq!(convert_remove_params_to_args(&params).branch, "main");
+
+            // Feature branch
+            let params = ChangesetRemoveParams::new(".", "feature/new-api");
+            assert_eq!(convert_remove_params_to_args(&params).branch, "feature/new-api");
+
+            // Hotfix branch
+            let params = ChangesetRemoveParams::new(".", "hotfix/critical-fix");
+            assert_eq!(convert_remove_params_to_args(&params).branch, "hotfix/critical-fix");
+
+            // Branch with multiple slashes
+            let params = ChangesetRemoveParams::new(".", "feature/auth/oauth");
+            assert_eq!(convert_remove_params_to_args(&params).branch, "feature/auth/oauth");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation Tests
+    // -------------------------------------------------------------------------
+
+    mod validation_tests {
+        use super::*;
+        use std::fs::File;
+
+        #[test]
+        fn test_validate_remove_params_valid_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let params =
+                ChangesetRemoveParams::new(temp_dir.path().to_str().unwrap(), "feature/test");
+
+            let result = validate_remove_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_remove_params_nonexistent_path() {
+            let params = ChangesetRemoveParams::new("/nonexistent/path/12345", "feature/test");
+
+            let result = validate_remove_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "ENOENT");
+        }
+
+        #[test]
+        fn test_validate_remove_params_empty_root() {
+            let params = ChangesetRemoveParams::new("", "feature/test");
+
+            let result = validate_remove_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("root"));
+        }
+
+        #[test]
+        fn test_validate_remove_params_file_not_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let file_path = temp_dir.path().join("test_file.txt");
+            let _ = File::create(&file_path).unwrap();
+
+            let params = ChangesetRemoveParams::new(file_path.to_str().unwrap(), "feature/test");
+
+            let result = validate_remove_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("directory"));
+        }
+
+        #[test]
+        fn test_validate_remove_params_empty_branch() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetRemoveParams::new(temp_dir.path().to_str().unwrap(), "");
+
+            let result = validate_remove_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("branch"));
+        }
+
+        #[test]
+        fn test_validate_remove_params_whitespace_branch() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetRemoveParams::new(temp_dir.path().to_str().unwrap(), "   ");
+
+            let result = validate_remove_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("branch"));
+        }
+
+        #[test]
+        fn test_validate_remove_params_with_config_path() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetRemoveParams {
+                root: temp_dir.path().to_str().unwrap().to_string(),
+                config_path: Some("/path/to/config.json".to_string()),
+                branch: "feature/test".to_string(),
+                force: None,
+            };
+
+            let result = validate_remove_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_remove_params_various_branch_names() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // Feature branch
+            let params =
+                ChangesetRemoveParams::new(temp_dir.path().to_str().unwrap(), "feature/new-api");
+            assert!(validate_remove_params(&params).is_ok());
+
+            // Hotfix branch
+            let params = ChangesetRemoveParams::new(
+                temp_dir.path().to_str().unwrap(),
+                "hotfix/security-patch",
+            );
+            assert!(validate_remove_params(&params).is_ok());
+
+            // Simple branch
+            let params = ChangesetRemoveParams::new(temp_dir.path().to_str().unwrap(), "main");
+            assert!(validate_remove_params(&params).is_ok());
+
+            // Branch with multiple slashes
+            let params = ChangesetRemoveParams::new(
+                temp_dir.path().to_str().unwrap(),
+                "feature/auth/oauth-integration",
+            );
+            assert!(validate_remove_params(&params).is_ok());
+
+            // Branch with numbers
+            let params =
+                ChangesetRemoveParams::new(temp_dir.path().to_str().unwrap(), "release/v2.0.0");
+            assert!(validate_remove_params(&params).is_ok());
+
+            // Branch with underscores and dashes
+            let params = ChangesetRemoveParams::new(
+                temp_dir.path().to_str().unwrap(),
+                "feature/my_feature-branch",
+            );
+            assert!(validate_remove_params(&params).is_ok());
+        }
+
+        #[test]
+        fn test_validate_remove_params_with_force_flag() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // With force = true
+            let params =
+                ChangesetRemoveParams::new(temp_dir.path().to_str().unwrap(), "feature/test")
+                    .with_force(true);
+            assert!(validate_remove_params(&params).is_ok());
+
+            // With force = false (should still validate, force is only used at execution)
+            let params =
+                ChangesetRemoveParams::new(temp_dir.path().to_str().unwrap(), "feature/test")
+                    .with_force(false);
+            assert!(validate_remove_params(&params).is_ok());
+        }
+    }
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -145,7 +145,8 @@ pub use commands::changeset_update;
 pub use commands::changeset_list;
 // Story 4.5: changesetShow
 pub use commands::changeset_show;
-// TODO: will be implemented on story 4.6 (changesetRemove)
+// Story 4.6: changesetRemove
+pub use commands::changeset_remove;
 // TODO: will be implemented on story 4.7 (changesetHistory)
 // TODO: will be implemented on story 4.8 (changesetCheck)
 // TODO: will be implemented on story 5.2-5.4 (bump commands)

--- a/packages/workspace-tools/npm/darwin-arm64/package.json
+++ b/packages/workspace-tools/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-arm64",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/darwin-x64/package.json
+++ b/packages/workspace-tools/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-x64",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-gnu",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-musl",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-gnu",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-musl",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/win32-arm64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-arm64-msvc",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/win32-x64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-x64-msvc",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Bindings for node from crate workspace-tools",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/types/index.d.cts",

--- a/packages/workspace-tools/src/binding.d.ts
+++ b/packages/workspace-tools/src/binding.d.ts
@@ -1041,6 +1041,117 @@ export interface ChangesetListParams {
 }
 
 /**
+ * Remove a changeset from the workspace.
+ *
+ * Deletes a changeset identified by its branch name. The changeset is archived
+ * before deletion for recovery purposes. In API mode, the operation always
+ * proceeds without confirmation (equivalent to `--force` flag in CLI).
+ *
+ * @param params - Changeset remove parameters containing:
+ *   - `root`: Workspace root directory path (required)
+ *   - `configPath`: Optional custom config file path
+ *   - `branch`: Branch name or changeset ID to remove (required)
+ *   - `force`: Ignored in API mode (always treated as true)
+ *
+ * @returns `Promise<ChangesetRemoveApiResponse>` - Response containing:
+ *   - `success`: Whether the operation succeeded
+ *   - `data`: Removal confirmation if successful
+ *   - `error`: Error information if failed
+ *
+ * ## Success Response
+ *
+ * When successful, `data` contains:
+ * - `removed`: Boolean indicating the changeset was removed (always true on success)
+ * - `branch`: The branch name that was removed
+ *
+ * ## Behavior Notes
+ *
+ * - The changeset is archived before deletion for potential recovery
+ * - The archive includes a marker indicating manual deletion (not a release)
+ * - In API mode, no confirmation prompt is shown (force mode is implicit)
+ *
+ * ## Error Codes
+ *
+ * - `EVALIDATION`: Invalid parameters (empty root or branch)
+ * - `ENOENT`: Path or changeset not found
+ * - `ECONFIG`: Workspace not initialized
+ * - `EEXECUTION`: CLI command failed
+ *
+ * @example Basic usage
+ * ```typescript
+ * const result = await changesetRemove({
+ *   root: '/path/to/workspace',
+ *   branch: 'feature/abandoned-work'
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Removed changeset: ${result.data.branch}`);
+ * } else {
+ *   console.error(`Error: ${result.error.message}`);
+ * }
+ * ```
+ *
+ * @example With custom config
+ * ```typescript
+ * const result = await changesetRemove({
+ *   root: '/path/to/workspace',
+ *   configPath: '/path/to/custom.config.json',
+ *   branch: 'feature/obsolete'
+ * });
+ * ```
+ *
+ * @example Error handling
+ * ```typescript
+ * const result = await changesetRemove({
+ *   root: '/path/to/workspace',
+ *   branch: 'nonexistent-branch'
+ * });
+ *
+ * if (!result.success) {
+ *   switch (result.error.code) {
+ *     case 'ENOENT':
+ *       console.error('Changeset not found');
+ *       break;
+ *     case 'EVALIDATION':
+ *       console.error('Invalid parameters:', result.error.message);
+ *       break;
+ *     case 'ECONFIG':
+ *       console.error('Workspace not initialized');
+ *       break;
+ *     default:
+ *       console.error(`Error: ${result.error.message}`);
+ *   }
+ * }
+ * ```
+ *
+ * @example Cleanup workflow
+ * ```typescript
+ * // List all changesets, then remove stale ones
+ * const listResult = await changesetList({ root: '.' });
+ *
+ * if (listResult.success) {
+ *   for (const changeset of listResult.data.changesets) {
+ *     // Check if changeset is older than 30 days
+ *     const createdAt = new Date(changeset.createdAt);
+ *     const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+ *
+ *     if (createdAt < thirtyDaysAgo) {
+ *       const removeResult = await changesetRemove({
+ *         root: '.',
+ *         branch: changeset.branch
+ *       });
+ *
+ *       if (removeResult.success) {
+ *         console.log(`Removed stale changeset: ${changeset.branch}`);
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export declare function changesetRemove(params: ChangesetRemoveParams): Promise<ChangesetRemoveApiResponse>
+
+/**
  * API response for the changeset remove command.
  *
  * Wraps `ChangesetRemoveData` with success/error handling.
@@ -1147,7 +1258,7 @@ export interface ChangesetRemoveParams {
  *   - `configPath`: Optional custom config file path
  *   - `branch`: Branch name or changeset ID (required)
  *
- * @returns Promise<ChangesetShowApiResponse> - Response containing:
+ * @returns `Promise<ChangesetShowApiResponse>` - Response containing:
  *   - `success`: Whether the operation succeeded
  *   - `data`: Changeset details if successful
  *   - `error`: Error information if failed

--- a/packages/workspace-tools/src/binding.js
+++ b/packages/workspace-tools/src/binding.js
@@ -574,6 +574,7 @@ if (!nativeBinding) {
 module.exports = nativeBinding
 module.exports.changesetAdd = nativeBinding.changesetAdd
 module.exports.changesetList = nativeBinding.changesetList
+module.exports.changesetRemove = nativeBinding.changesetRemove
 module.exports.changesetShow = nativeBinding.changesetShow
 module.exports.changesetUpdate = nativeBinding.changesetUpdate
 module.exports.getVersion = nativeBinding.getVersion

--- a/packages/workspace-tools/src/index.ts
+++ b/packages/workspace-tools/src/index.ts
@@ -14,7 +14,8 @@
  * - `changesetUpdate()` - Update an existing changeset (Story 4.3)
  * - `changesetList()` - List pending changesets with filtering (Story 4.4)
  * - `changesetShow()` - Show details of a specific changeset (Story 4.5)
- * - Changeset types for upcoming changeset commands (Stories 4.6-4.8)
+ * - `changesetRemove()` - Remove a changeset from the workspace (Story 4.6)
+ * - Changeset types for upcoming changeset commands (Stories 4.7-4.8)
  *
  * ## How
  *
@@ -34,9 +35,9 @@
  */
 
 // Re-export all functions from bindings
-import { changesetAdd, changesetList, changesetShow, changesetUpdate, getVersion, init, status } from './binding'
+import { changesetAdd, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status } from './binding'
 
-export { changesetAdd, changesetList, changesetShow, changesetUpdate, getVersion, init, status }
+export { changesetAdd, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status }
 
 // Re-export all types from bindings
 export type {


### PR DESCRIPTION
- Add changeset_remove NAPI function with CLI response types
- Add validation for root path and branch parameters
- Add conversion functions for params to CLI args
- Add JSON response parsing with proper error handling
- Force mode always enabled in API (no interactive prompts)
- Add 34 unit tests for parsing, conversion, and validation
- Update exports in mod.rs and lib.rs
- Regenerate Node.js bindings and update index.ts exports
- Bump package version to 2.0.7

Story 4.6: Implement changesetRemove