### PR TITLE
feat(WOR-TSK-188): implement changesetHistory NAPI function

### DIFF
--- a/crates/node/src/commands/changeset.rs
+++ b/crates/node/src/commands/changeset.rs
@@ -100,20 +100,22 @@ use serde::Deserialize;
 
 use crate::error::ErrorInfo;
 use crate::types::changeset::{
-    ChangesetAddApiResponse, ChangesetAddData, ChangesetAddParams, ChangesetDetailInfo,
+    ArchivedChangesetInfo, ChangesetAddApiResponse, ChangesetAddData, ChangesetAddParams,
+    ChangesetDetailInfo, ChangesetHistoryApiResponse, ChangesetHistoryData, ChangesetHistoryParams,
     ChangesetListApiResponse, ChangesetListData, ChangesetListItemInfo, ChangesetListParams,
     ChangesetRemoveApiResponse, ChangesetRemoveData, ChangesetRemoveParams,
     ChangesetShowApiResponse, ChangesetShowData, ChangesetShowParams, ChangesetUpdateApiResponse,
-    ChangesetUpdateData, ChangesetUpdateParams, UpdateSummaryInfo, VALID_SORT_OPTIONS,
+    ChangesetUpdateData, ChangesetUpdateParams, ReleaseInfoData, ReleasedVersionEntry,
+    UpdateSummaryInfo, VALID_SORT_OPTIONS,
 };
 use crate::validation::validators;
 
 use sublime_cli_tools::cli::commands::{
-    ChangesetCreateArgs, ChangesetDeleteArgs, ChangesetListArgs, ChangesetShowArgs,
-    ChangesetUpdateArgs,
+    ChangesetCreateArgs, ChangesetDeleteArgs, ChangesetHistoryArgs, ChangesetListArgs,
+    ChangesetShowArgs, ChangesetUpdateArgs,
 };
 use sublime_cli_tools::commands::changeset::{
-    execute_add, execute_list, execute_remove, execute_show, execute_update,
+    execute_add, execute_history, execute_list, execute_remove, execute_show, execute_update,
 };
 use sublime_cli_tools::output::{Output, OutputFormat};
 
@@ -1979,6 +1981,466 @@ pub async fn changeset_remove(params: ChangesetRemoveParams) -> ChangesetRemoveA
         Ok(Ok(data)) => ChangesetRemoveApiResponse::success(data),
         Ok(Err(error)) => ChangesetRemoveApiResponse::failure(error),
         Err(join_error) => ChangesetRemoveApiResponse::failure(ErrorInfo::execution(format!(
+            "Task execution failed: {join_error}"
+        ))),
+    }
+}
+
+// ============================================================================
+// Changeset History - CLI Response Types
+// ============================================================================
+
+/// CLI JSON response data structure for changeset history command.
+///
+/// This structure mirrors the `ChangesetHistoryResponse` from the CLI's history command,
+/// used for deserializing the captured JSON output.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliChangesetHistoryResponseData {
+    /// Whether the operation succeeded.
+    #[allow(dead_code)]
+    pub(crate) success: bool,
+
+    /// List of archived changesets.
+    pub(crate) changesets: Vec<CliArchivedChangesetInfo>,
+
+    /// Total count of results.
+    #[allow(dead_code)]
+    pub(crate) total: usize,
+}
+
+/// Archived changeset information from CLI history output.
+///
+/// Contains both changeset details and release information.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliArchivedChangesetInfo {
+    /// Branch name (also serves as unique identifier).
+    pub(crate) branch: String,
+
+    /// Version bump type (major, minor, patch, none).
+    pub(crate) bump: String,
+
+    /// List of affected packages.
+    pub(crate) packages: Vec<String>,
+
+    /// Target environments.
+    pub(crate) environments: Vec<String>,
+
+    /// List of commit IDs.
+    pub(crate) commits: Vec<String>,
+
+    /// Changeset creation timestamp (RFC3339 format).
+    pub(crate) created_at: String,
+
+    /// Changeset last update timestamp (RFC3339 format).
+    pub(crate) updated_at: String,
+
+    /// Package versions map (package name -> version).
+    pub(crate) versions: std::collections::HashMap<String, String>,
+
+    /// Git commit hash of the release.
+    pub(crate) git_commit: String,
+
+    /// Release timestamp (RFC3339 format).
+    pub(crate) applied_at: String,
+
+    /// User/system that performed the release.
+    pub(crate) applied_by: String,
+}
+
+// ============================================================================
+// Changeset History - Conversion Functions
+// ============================================================================
+
+/// Converts a CLI archived changeset info to NAPI `ArchivedChangesetInfo`.
+///
+/// Maps the flat CLI structure to the nested NAPI structure with separate
+/// changeset details and release information sections.
+///
+/// # Arguments
+///
+/// * `cli` - The CLI archived changeset info to convert
+///
+/// # Returns
+///
+/// A NAPI-compatible `ArchivedChangesetInfo` instance.
+pub(crate) fn convert_archived_changeset_to_napi(
+    cli: CliArchivedChangesetInfo,
+) -> ArchivedChangesetInfo {
+    // Convert versions HashMap to Vec<ReleasedVersionEntry>
+    let released_versions: Vec<ReleasedVersionEntry> = cli
+        .versions
+        .into_iter()
+        .map(|(package_name, version)| ReleasedVersionEntry::new(package_name, version))
+        .collect();
+
+    // Build the changeset detail info
+    let changeset = ChangesetDetailInfo::new(
+        cli.branch.clone(),
+        cli.branch.clone(),
+        cli.bump,
+        cli.created_at,
+        cli.updated_at,
+    )
+    .with_packages(cli.packages)
+    .with_environments(cli.environments)
+    .with_commits(cli.commits);
+
+    // Build the release info
+    let release_info =
+        ReleaseInfoData::new(cli.applied_at, cli.applied_by, cli.git_commit, released_versions);
+
+    ArchivedChangesetInfo::new(changeset, release_info)
+}
+
+/// Converts CLI history response to NAPI `ChangesetHistoryData`.
+///
+/// # Arguments
+///
+/// * `cli_data` - The CLI response data to convert
+///
+/// # Returns
+///
+/// A NAPI-compatible `ChangesetHistoryData` instance.
+pub(crate) fn convert_to_napi_history_data(
+    cli_data: CliChangesetHistoryResponseData,
+) -> ChangesetHistoryData {
+    let archived: Vec<ArchivedChangesetInfo> =
+        cli_data.changesets.into_iter().map(convert_archived_changeset_to_napi).collect();
+
+    ChangesetHistoryData::new(archived)
+}
+
+// ============================================================================
+// Changeset History - Response Parsing
+// ============================================================================
+
+/// Parses the JSON output from the CLI history command.
+///
+/// Handles both success and error responses from the CLI, converting them
+/// to the appropriate NAPI types.
+///
+/// # Arguments
+///
+/// * `json_bytes` - Raw bytes from the CLI output buffer
+///
+/// # Returns
+///
+/// A `ChangesetHistoryData` on success, or an `ErrorInfo` on failure.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The output buffer is empty
+/// - The bytes cannot be converted to UTF-8
+/// - The JSON cannot be parsed
+/// - The CLI returned an error response
+pub(crate) fn parse_changeset_history_response(
+    json_bytes: &[u8],
+) -> Result<ChangesetHistoryData, ErrorInfo> {
+    // Check for empty output
+    if json_bytes.is_empty() {
+        return Err(ErrorInfo::execution("CLI returned empty output"));
+    }
+
+    // Convert bytes to string
+    let json_str = std::str::from_utf8(json_bytes)
+        .map_err(|e| ErrorInfo::execution(format!("Invalid UTF-8 in CLI output: {e}")))?;
+
+    // Trim whitespace
+    let json_str = json_str.trim();
+    if json_str.is_empty() {
+        return Err(ErrorInfo::execution("CLI returned empty output"));
+    }
+
+    // Parse the JSON response
+    let cli_response: CliJsonResponse<CliChangesetHistoryResponseData> =
+        serde_json::from_str(json_str)
+            .map_err(|e| ErrorInfo::execution(format!("Failed to parse CLI JSON output: {e}")))?;
+
+    // Check for CLI-level error
+    if !cli_response.success {
+        let error_msg = cli_response.error.unwrap_or_else(|| String::from("Unknown CLI error"));
+        return Err(ErrorInfo::execution(error_msg));
+    }
+
+    // Extract data or return error
+    let cli_data = cli_response
+        .data
+        .ok_or_else(|| ErrorInfo::execution("CLI returned success but no data"))?;
+
+    // Convert to NAPI types
+    Ok(convert_to_napi_history_data(cli_data))
+}
+
+// ============================================================================
+// Changeset History - Validation
+// ============================================================================
+
+/// Validates the history command parameters.
+///
+/// Checks that:
+/// - The root path is not empty
+/// - The root path exists and is a directory
+/// - If filter_bump is provided, it's a valid bump type
+///
+/// # Arguments
+///
+/// * `params` - The history parameters to validate
+///
+/// # Returns
+///
+/// The validated root path as a `PathBuf` on success, or an `ErrorInfo` on failure.
+pub(crate) fn validate_history_params(
+    params: &ChangesetHistoryParams,
+) -> Result<PathBuf, ErrorInfo> {
+    // Validate root path exists and is a directory
+    validators::root(&params.root)?;
+
+    // Validate bump type if provided
+    if let Some(ref bump) = params.filter_bump {
+        validators::bump_type_info(bump)?;
+    }
+
+    Ok(PathBuf::from(&params.root))
+}
+
+// ============================================================================
+// Changeset History - Parameter Conversion
+// ============================================================================
+
+/// Converts NAPI history params to CLI args.
+///
+/// Maps the JavaScript-friendly parameter names to the CLI argument structure.
+///
+/// # Arguments
+///
+/// * `params` - The NAPI parameters to convert
+///
+/// # Returns
+///
+/// A `ChangesetHistoryArgs` instance ready for CLI execution.
+pub(crate) fn convert_history_params_to_args(
+    params: &ChangesetHistoryParams,
+) -> ChangesetHistoryArgs {
+    ChangesetHistoryArgs {
+        filter_package: params.filter_package.clone(),
+        filter_env: params.filter_env.clone(),
+        filter_bump: params.filter_bump.clone(),
+        since: params.since.clone(),
+        until: params.until.clone(),
+        limit: params.limit.map(|l| l as usize),
+    }
+}
+
+// ============================================================================
+// Changeset History - NAPI Function
+// ============================================================================
+
+/// Queries the changeset history with optional filtering.
+///
+/// This function queries archived changesets from the workspace history,
+/// supporting various filter options for package, environment, bump type,
+/// date range, and result limit.
+///
+/// # Parameters
+///
+/// - `root`: Workspace root directory path (required)
+/// - `configPath`: Optional path to custom configuration file
+/// - `filterPackage`: Filter by package name
+/// - `filterEnv`: Filter by environment
+/// - `filterBump`: Filter by bump type (major, minor, patch)
+/// - `since`: Start date filter (ISO 8601 format)
+/// - `until`: End date filter (ISO 8601 format)
+/// - `limit`: Maximum number of results
+///
+/// # Returns
+///
+/// An `ApiResponse` containing `ChangesetHistoryData` with the list of archived
+/// changesets matching the query, or an error if the operation fails.
+///
+/// ## Success Response
+///
+/// ```typescript
+/// {
+///   success: true,
+///   data: {
+///     archived: [
+///       {
+///         changeset: {
+///           id: "feature/add-api",
+///           branch: "feature/add-api",
+///           bump: "minor",
+///           packages: ["@scope/core"],
+///           environments: ["production"],
+///           commits: ["abc123"],
+///           createdAt: "2024-01-15T10:30:00Z",
+///           updatedAt: "2024-01-15T14:45:00Z"
+///         },
+///         releaseInfo: {
+///           releasedAt: "2024-01-16T10:00:00Z",
+///           releasedBy: "CI",
+///           releaseCommit: "def456",
+///           releasedVersions: [
+///             { packageName: "@scope/core", version: "2.0.0" }
+///           ]
+///         }
+///       }
+///     ],
+///     count: 1
+///   }
+/// }
+/// ```
+///
+/// ## Error Codes
+///
+/// - `EVALIDATION`: Invalid parameters (empty root or invalid bump type)
+/// - `ENOENT`: Path not found
+/// - `ECONFIG`: Workspace not initialized
+/// - `EEXECUTION`: CLI command failed
+///
+/// @example Basic usage - get all history
+/// ```typescript
+/// const result = await changesetHistory({
+///   root: '/path/to/workspace'
+/// });
+///
+/// if (result.success) {
+///   console.log(`Found ${result.data.count} archived changesets`);
+///   for (const item of result.data.archived) {
+///     console.log(`- ${item.changeset.branch}: ${item.changeset.bump}`);
+///     console.log(`  Released: ${item.releaseInfo.releasedAt}`);
+///   }
+/// }
+/// ```
+///
+/// @example Filter by package
+/// ```typescript
+/// const result = await changesetHistory({
+///   root: '/path/to/workspace',
+///   filterPackage: '@scope/core'
+/// });
+///
+/// if (result.success) {
+///   console.log(`Releases for @scope/core: ${result.data.count}`);
+/// }
+/// ```
+///
+/// @example Filter by date range
+/// ```typescript
+/// const result = await changesetHistory({
+///   root: '/path/to/workspace',
+///   since: '2024-01-01',
+///   until: '2024-12-31',
+///   limit: 10
+/// });
+/// ```
+///
+/// @example Filter by bump type
+/// ```typescript
+/// const result = await changesetHistory({
+///   root: '/path/to/workspace',
+///   filterBump: 'major'
+/// });
+///
+/// if (result.success) {
+///   console.log('Major releases:');
+///   result.data.archived.forEach(item => {
+///     const versions = item.releaseInfo.releasedVersions
+///       .map(v => `${v.packageName}@${v.version}`)
+///       .join(', ');
+///     console.log(`  ${item.changeset.branch}: ${versions}`);
+///   });
+/// }
+/// ```
+///
+/// @example Multiple filters
+/// ```typescript
+/// const result = await changesetHistory({
+///   root: '/path/to/workspace',
+///   filterPackage: '@scope/core',
+///   filterEnv: 'production',
+///   filterBump: 'minor',
+///   since: '2024-06-01',
+///   limit: 5
+/// });
+/// ```
+///
+/// @example Error handling
+/// ```typescript
+/// const result = await changesetHistory({
+///   root: '/nonexistent/path'
+/// });
+///
+/// if (!result.success) {
+///   switch (result.error.code) {
+///     case 'ENOENT':
+///       console.error('Path not found');
+///       break;
+///     case 'EVALIDATION':
+///       console.error('Invalid parameters:', result.error.message);
+///       break;
+///     case 'ECONFIG':
+///       console.error('Workspace not initialized');
+///       break;
+///     default:
+///       console.error(`Error: ${result.error.message}`);
+///   }
+/// }
+/// ```
+#[napi(js_name = "changesetHistory")]
+pub async fn changeset_history(params: ChangesetHistoryParams) -> ChangesetHistoryApiResponse {
+    // 1. Validate parameters (synchronous validation before spawning)
+    let root_path = match validate_history_params(&params) {
+        Ok(path) => path,
+        Err(error) => return ChangesetHistoryApiResponse::failure(error),
+    };
+
+    // 2. Prepare config path
+    let config_path: Option<PathBuf> = params.config_path.as_ref().map(PathBuf::from);
+
+    // 3. Convert NAPI params to CLI args
+    let args = convert_history_params_to_args(&params);
+
+    // 4. Execute CLI command in a blocking task
+    // The CLI's execute_history uses types that are not Send/Sync (RefCell, git2::Repository),
+    // so we must run it on a blocking thread via spawn_blocking.
+    let result = tokio::task::spawn_blocking(move || {
+        // Create a new tokio runtime for the blocking context
+        // This is necessary because execute_history is async but we're in a blocking context
+        let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                return Err(ErrorInfo::execution(format!("Failed to create runtime: {e}")));
+            }
+        };
+
+        rt.block_on(async {
+            // Create shared buffer for output capture
+            let buffer = SharedBuffer::new();
+
+            // Create Output with JSON format
+            let output = Output::new(OutputFormat::Json, buffer.clone(), true);
+
+            // Execute the CLI command
+            if let Err(cli_error) =
+                execute_history(&args, &output, Some(root_path.as_path()), config_path.as_deref())
+                    .await
+            {
+                return Err(ErrorInfo::from(cli_error));
+            }
+
+            // Extract and parse JSON
+            let json_bytes = buffer.take_bytes();
+            parse_changeset_history_response(&json_bytes)
+        })
+    })
+    .await;
+
+    // 5. Handle spawn_blocking result
+    match result {
+        Ok(Ok(data)) => ChangesetHistoryApiResponse::success(data),
+        Ok(Err(error)) => ChangesetHistoryApiResponse::failure(error),
+        Err(join_error) => ChangesetHistoryApiResponse::failure(ErrorInfo::execution(format!(
             "Task execution failed: {join_error}"
         ))),
     }

--- a/crates/node/src/commands/mod.rs
+++ b/crates/node/src/commands/mod.rs
@@ -76,7 +76,8 @@ pub use changeset::changeset_list;
 pub use changeset::changeset_show;
 // Story 4.6: changesetRemove
 pub use changeset::changeset_remove;
-// TODO: will be implemented on story 4.7 (changesetHistory)
+// Story 4.7: changesetHistory
+pub use changeset::changeset_history;
 // TODO: will be implemented on story 4.8 (changesetCheck)
 
 // Tests module for all command implementations

--- a/crates/node/src/commands/tests.rs
+++ b/crates/node/src/commands/tests.rs
@@ -3213,3 +3213,535 @@ mod changeset_remove_tests {
         }
     }
 }
+
+// ============================================================================
+// Changeset History Tests
+// ============================================================================
+
+/// Tests for the changeset history command implementation.
+///
+/// This module covers:
+/// - SharedBuffer functionality for output capture
+/// - Response parsing from CLI JSON output
+/// - Conversion of CLI types to NAPI types
+/// - Parameter validation
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod changeset_history_tests {
+    use std::collections::HashMap;
+
+    use tempfile::TempDir;
+
+    use crate::commands::changeset::{
+        CliArchivedChangesetInfo, CliChangesetHistoryResponseData, SharedBuffer,
+        convert_archived_changeset_to_napi, convert_history_params_to_args,
+        convert_to_napi_history_data, parse_changeset_history_response, validate_history_params,
+    };
+    use crate::types::changeset::ChangesetHistoryParams;
+
+    // ========================================================================
+    // SharedBuffer Tests
+    // ========================================================================
+
+    mod shared_buffer_tests {
+        use super::*;
+        use std::io::Write;
+
+        #[test]
+        fn test_shared_buffer_new() {
+            let buffer = SharedBuffer::new();
+            assert!(buffer.take_bytes().is_empty());
+        }
+
+        #[test]
+        fn test_shared_buffer_write() {
+            let mut buffer = SharedBuffer::new();
+            let _ = buffer.write(b"test data");
+            assert_eq!(buffer.take_bytes(), b"test data");
+        }
+
+        #[test]
+        fn test_shared_buffer_multiple_writes() {
+            let mut buffer = SharedBuffer::new();
+            let _ = buffer.write(b"first ");
+            let _ = buffer.write(b"second");
+            assert_eq!(buffer.take_bytes(), b"first second");
+        }
+
+        #[test]
+        fn test_shared_buffer_clone_shares_data() {
+            let mut buffer = SharedBuffer::new();
+            let clone = buffer.clone();
+            let _ = buffer.write(b"shared data");
+            // Clone should see the same data
+            assert_eq!(clone.take_bytes(), b"shared data");
+        }
+
+        #[test]
+        fn test_shared_buffer_flush() {
+            let mut buffer = SharedBuffer::new();
+            assert!(buffer.flush().is_ok());
+        }
+
+        #[test]
+        fn test_shared_buffer_take_bytes_preserves_data() {
+            let mut buffer = SharedBuffer::new();
+            let _ = buffer.write(b"preserved");
+            let first = buffer.take_bytes();
+            let second = buffer.take_bytes();
+            assert_eq!(first, second);
+        }
+    }
+
+    // ========================================================================
+    // Parse Response Tests
+    // ========================================================================
+
+    mod parse_response_tests {
+        use super::*;
+
+        #[test]
+        fn test_parse_changeset_history_response_success() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "success": true,
+                    "changesets": [
+                        {
+                            "branch": "feature/add-api",
+                            "bump": "minor",
+                            "packages": ["@scope/core"],
+                            "environments": ["production"],
+                            "commits": ["abc123", "def456"],
+                            "created_at": "2024-01-15T10:30:00Z",
+                            "updated_at": "2024-01-15T14:45:00Z",
+                            "versions": {"@scope/core": "2.0.0"},
+                            "git_commit": "release123",
+                            "applied_at": "2024-01-16T10:00:00Z",
+                            "applied_by": "CI"
+                        }
+                    ],
+                    "total": 1
+                }
+            }"#;
+
+            let result = parse_changeset_history_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            assert_eq!(data.count, 1);
+            assert_eq!(data.archived.len(), 1);
+
+            let archived = &data.archived[0];
+            assert_eq!(archived.changeset.branch, "feature/add-api");
+            assert_eq!(archived.changeset.bump, "minor");
+            assert_eq!(archived.changeset.packages, vec!["@scope/core"]);
+            assert_eq!(archived.changeset.environments, vec!["production"]);
+            assert_eq!(archived.changeset.commits, vec!["abc123", "def456"]);
+            assert_eq!(archived.release_info.released_by, "CI");
+            assert_eq!(archived.release_info.release_commit, "release123");
+            assert_eq!(archived.release_info.released_versions.len(), 1);
+            assert_eq!(archived.release_info.released_versions[0].package_name, "@scope/core");
+            assert_eq!(archived.release_info.released_versions[0].version, "2.0.0");
+        }
+
+        #[test]
+        fn test_parse_changeset_history_response_empty_list() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "success": true,
+                    "changesets": [],
+                    "total": 0
+                }
+            }"#;
+
+            let result = parse_changeset_history_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            assert_eq!(data.count, 0);
+            assert!(data.archived.is_empty());
+        }
+
+        #[test]
+        fn test_parse_changeset_history_response_multiple_items() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "success": true,
+                    "changesets": [
+                        {
+                            "branch": "feature/first",
+                            "bump": "major",
+                            "packages": ["@scope/pkg1"],
+                            "environments": [],
+                            "commits": ["abc"],
+                            "created_at": "2024-01-01T00:00:00Z",
+                            "updated_at": "2024-01-01T00:00:00Z",
+                            "versions": {"@scope/pkg1": "1.0.0"},
+                            "git_commit": "commit1",
+                            "applied_at": "2024-01-02T00:00:00Z",
+                            "applied_by": "user1"
+                        },
+                        {
+                            "branch": "feature/second",
+                            "bump": "patch",
+                            "packages": ["@scope/pkg2"],
+                            "environments": ["staging"],
+                            "commits": ["def"],
+                            "created_at": "2024-02-01T00:00:00Z",
+                            "updated_at": "2024-02-01T00:00:00Z",
+                            "versions": {"@scope/pkg2": "1.0.1"},
+                            "git_commit": "commit2",
+                            "applied_at": "2024-02-02T00:00:00Z",
+                            "applied_by": "user2"
+                        }
+                    ],
+                    "total": 2
+                }
+            }"#;
+
+            let result = parse_changeset_history_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            assert_eq!(data.count, 2);
+            assert_eq!(data.archived.len(), 2);
+
+            assert_eq!(data.archived[0].changeset.branch, "feature/first");
+            assert_eq!(data.archived[1].changeset.branch, "feature/second");
+        }
+
+        #[test]
+        fn test_parse_changeset_history_response_cli_error() {
+            let json = r#"{"success": false, "error": "Workspace not initialized"}"#;
+            let result = parse_changeset_history_response(json.as_bytes());
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Workspace not initialized"));
+        }
+
+        #[test]
+        fn test_parse_changeset_history_response_empty() {
+            let result = parse_changeset_history_response(b"");
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("empty output"));
+        }
+
+        #[test]
+        fn test_parse_changeset_history_response_whitespace_only() {
+            let result = parse_changeset_history_response(b"   \n\t  ");
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("empty output"));
+        }
+
+        #[test]
+        fn test_parse_changeset_history_response_invalid_json() {
+            let result = parse_changeset_history_response(b"not json");
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("Failed to parse"));
+        }
+
+        #[test]
+        fn test_parse_changeset_history_response_invalid_utf8() {
+            let invalid_utf8 = vec![0xFF, 0xFE, 0x00, 0x01];
+            let result = parse_changeset_history_response(&invalid_utf8);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("Invalid UTF-8"));
+        }
+
+        #[test]
+        fn test_parse_changeset_history_response_success_no_data() {
+            let json = r#"{"success": true}"#;
+            let result = parse_changeset_history_response(json.as_bytes());
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("success but no data"));
+        }
+
+        #[test]
+        fn test_parse_changeset_history_response_cli_error_no_message() {
+            let json = r#"{"success": false}"#;
+            let result = parse_changeset_history_response(json.as_bytes());
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("Unknown CLI error"));
+        }
+    }
+
+    // ========================================================================
+    // Conversion Tests
+    // ========================================================================
+
+    mod conversion_tests {
+        use super::*;
+
+        #[test]
+        fn test_convert_archived_changeset_to_napi() {
+            let mut versions = HashMap::new();
+            versions.insert("@scope/core".to_string(), "2.0.0".to_string());
+            versions.insert("@scope/utils".to_string(), "1.5.0".to_string());
+
+            let cli = CliArchivedChangesetInfo {
+                branch: "feature/add-api".to_string(),
+                bump: "minor".to_string(),
+                packages: vec!["@scope/core".to_string(), "@scope/utils".to_string()],
+                environments: vec!["production".to_string()],
+                commits: vec!["abc123".to_string()],
+                created_at: "2024-01-15T10:30:00Z".to_string(),
+                updated_at: "2024-01-15T14:45:00Z".to_string(),
+                versions,
+                git_commit: "release123".to_string(),
+                applied_at: "2024-01-16T10:00:00Z".to_string(),
+                applied_by: "CI".to_string(),
+            };
+
+            let result = convert_archived_changeset_to_napi(cli);
+
+            // Verify changeset details
+            assert_eq!(result.changeset.id, "feature/add-api");
+            assert_eq!(result.changeset.branch, "feature/add-api");
+            assert_eq!(result.changeset.bump, "minor");
+            assert_eq!(result.changeset.packages, vec!["@scope/core", "@scope/utils"]);
+            assert_eq!(result.changeset.environments, vec!["production"]);
+            assert_eq!(result.changeset.commits, vec!["abc123"]);
+            assert_eq!(result.changeset.created_at, "2024-01-15T10:30:00Z");
+            assert_eq!(result.changeset.updated_at, "2024-01-15T14:45:00Z");
+
+            // Verify release info
+            assert_eq!(result.release_info.released_at, "2024-01-16T10:00:00Z");
+            assert_eq!(result.release_info.released_by, "CI");
+            assert_eq!(result.release_info.release_commit, "release123");
+            assert_eq!(result.release_info.released_versions.len(), 2);
+        }
+
+        #[test]
+        fn test_convert_archived_changeset_empty_fields() {
+            let cli = CliArchivedChangesetInfo {
+                branch: "empty-branch".to_string(),
+                bump: "patch".to_string(),
+                packages: vec![],
+                environments: vec![],
+                commits: vec![],
+                created_at: "2024-01-01T00:00:00Z".to_string(),
+                updated_at: "2024-01-01T00:00:00Z".to_string(),
+                versions: HashMap::new(),
+                git_commit: "commit".to_string(),
+                applied_at: "2024-01-02T00:00:00Z".to_string(),
+                applied_by: "system".to_string(),
+            };
+
+            let result = convert_archived_changeset_to_napi(cli);
+
+            assert!(result.changeset.packages.is_empty());
+            assert!(result.changeset.environments.is_empty());
+            assert!(result.changeset.commits.is_empty());
+            assert!(result.release_info.released_versions.is_empty());
+        }
+
+        #[test]
+        fn test_convert_to_napi_history_data() {
+            let cli_data = CliChangesetHistoryResponseData {
+                success: true,
+                changesets: vec![CliArchivedChangesetInfo {
+                    branch: "test-branch".to_string(),
+                    bump: "major".to_string(),
+                    packages: vec!["pkg1".to_string()],
+                    environments: vec![],
+                    commits: vec![],
+                    created_at: "2024-01-01T00:00:00Z".to_string(),
+                    updated_at: "2024-01-01T00:00:00Z".to_string(),
+                    versions: HashMap::new(),
+                    git_commit: "abc".to_string(),
+                    applied_at: "2024-01-02T00:00:00Z".to_string(),
+                    applied_by: "user".to_string(),
+                }],
+                total: 1,
+            };
+
+            let result = convert_to_napi_history_data(cli_data);
+
+            assert_eq!(result.count, 1);
+            assert_eq!(result.archived.len(), 1);
+            assert_eq!(result.archived[0].changeset.branch, "test-branch");
+        }
+
+        #[test]
+        fn test_convert_to_napi_history_data_empty() {
+            let cli_data =
+                CliChangesetHistoryResponseData { success: true, changesets: vec![], total: 0 };
+
+            let result = convert_to_napi_history_data(cli_data);
+
+            assert_eq!(result.count, 0);
+            assert!(result.archived.is_empty());
+        }
+
+        #[test]
+        fn test_convert_history_params_to_args_defaults() {
+            let params = ChangesetHistoryParams::new(".");
+            let args = convert_history_params_to_args(&params);
+
+            assert!(args.filter_package.is_none());
+            assert!(args.filter_env.is_none());
+            assert!(args.filter_bump.is_none());
+            assert!(args.since.is_none());
+            assert!(args.until.is_none());
+            assert!(args.limit.is_none());
+        }
+
+        #[test]
+        fn test_convert_history_params_to_args_all_filters() {
+            let params = ChangesetHistoryParams::new(".")
+                .with_filter_package("@scope/core")
+                .with_filter_env("production")
+                .with_filter_bump("major")
+                .with_since("2024-01-01")
+                .with_until("2024-12-31")
+                .with_limit(10);
+            let args = convert_history_params_to_args(&params);
+
+            assert_eq!(args.filter_package, Some("@scope/core".to_string()));
+            assert_eq!(args.filter_env, Some("production".to_string()));
+            assert_eq!(args.filter_bump, Some("major".to_string()));
+            assert_eq!(args.since, Some("2024-01-01".to_string()));
+            assert_eq!(args.until, Some("2024-12-31".to_string()));
+            assert_eq!(args.limit, Some(10));
+        }
+
+        #[test]
+        fn test_convert_history_params_limit_conversion() {
+            // Test u32 to usize conversion
+            let params = ChangesetHistoryParams::new(".").with_limit(100);
+            let args = convert_history_params_to_args(&params);
+            assert_eq!(args.limit, Some(100));
+        }
+    }
+
+    // ========================================================================
+    // Validation Tests
+    // ========================================================================
+
+    mod validation_tests {
+        use super::*;
+
+        #[test]
+        fn test_validate_history_params_valid_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetHistoryParams::new(temp_dir.path().to_str().unwrap());
+            let result = validate_history_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_history_params_nonexistent_path() {
+            let params = ChangesetHistoryParams::new("/nonexistent/path/xyz");
+            let result = validate_history_params(&params);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn test_validate_history_params_empty_root() {
+            let params = ChangesetHistoryParams::new("");
+            let result = validate_history_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("empty"));
+        }
+
+        #[test]
+        fn test_validate_history_params_file_not_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let file_path = temp_dir.path().join("test.txt");
+            std::fs::write(&file_path, "test").unwrap();
+
+            let params = ChangesetHistoryParams::new(file_path.to_str().unwrap());
+            let result = validate_history_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("directory"));
+        }
+
+        #[test]
+        fn test_validate_history_params_valid_bump_types() {
+            let temp_dir = TempDir::new().unwrap();
+
+            for bump_type in ["major", "minor", "patch", "none"] {
+                let params = ChangesetHistoryParams::new(temp_dir.path().to_str().unwrap())
+                    .with_filter_bump(bump_type);
+                assert!(
+                    validate_history_params(&params).is_ok(),
+                    "Expected {bump_type} to be valid"
+                );
+            }
+        }
+
+        #[test]
+        fn test_validate_history_params_invalid_bump_type() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetHistoryParams::new(temp_dir.path().to_str().unwrap())
+                .with_filter_bump("invalid");
+            let result = validate_history_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("invalid"));
+        }
+
+        #[test]
+        fn test_validate_history_params_with_all_filters() {
+            let temp_dir = TempDir::new().unwrap();
+            let params = ChangesetHistoryParams::new(temp_dir.path().to_str().unwrap())
+                .with_filter_package("@scope/core")
+                .with_filter_env("production")
+                .with_filter_bump("major")
+                .with_since("2024-01-01")
+                .with_until("2024-12-31")
+                .with_limit(50);
+            assert!(validate_history_params(&params).is_ok());
+        }
+
+        #[test]
+        fn test_validate_history_params_with_config_path() {
+            let temp_dir = TempDir::new().unwrap();
+            let mut params = ChangesetHistoryParams::new(temp_dir.path().to_str().unwrap());
+            params.config_path = Some("/path/to/config.json".to_string());
+            // Config path validation happens at execution time, not validation time
+            assert!(validate_history_params(&params).is_ok());
+        }
+
+        #[test]
+        fn test_validate_history_params_date_filters() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // Only since date
+            let params = ChangesetHistoryParams::new(temp_dir.path().to_str().unwrap())
+                .with_since("2024-01-01");
+            assert!(validate_history_params(&params).is_ok());
+
+            // Only until date
+            let params = ChangesetHistoryParams::new(temp_dir.path().to_str().unwrap())
+                .with_until("2024-12-31");
+            assert!(validate_history_params(&params).is_ok());
+
+            // Both dates
+            let params = ChangesetHistoryParams::new(temp_dir.path().to_str().unwrap())
+                .with_since("2024-01-01")
+                .with_until("2024-12-31");
+            assert!(validate_history_params(&params).is_ok());
+        }
+
+        #[test]
+        fn test_validate_history_params_limit_values() {
+            let temp_dir = TempDir::new().unwrap();
+
+            // Zero limit is valid (means no results, which is valid)
+            let params =
+                ChangesetHistoryParams::new(temp_dir.path().to_str().unwrap()).with_limit(0);
+            assert!(validate_history_params(&params).is_ok());
+
+            // Large limit is valid
+            let params =
+                ChangesetHistoryParams::new(temp_dir.path().to_str().unwrap()).with_limit(1000);
+            assert!(validate_history_params(&params).is_ok());
+        }
+    }
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -147,7 +147,8 @@ pub use commands::changeset_list;
 pub use commands::changeset_show;
 // Story 4.6: changesetRemove
 pub use commands::changeset_remove;
-// TODO: will be implemented on story 4.7 (changesetHistory)
+// Story 4.7: changesetHistory
+pub use commands::changeset_history;
 // TODO: will be implemented on story 4.8 (changesetCheck)
 // TODO: will be implemented on story 5.2-5.4 (bump commands)
 // TODO: will be implemented on story 6.3 (execute command)

--- a/packages/workspace-tools/npm/darwin-arm64/package.json
+++ b/packages/workspace-tools/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-arm64",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/darwin-x64/package.json
+++ b/packages/workspace-tools/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-x64",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-gnu",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-musl",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-gnu",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-musl",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/win32-arm64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-arm64-msvc",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/win32-x64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-x64-msvc",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Bindings for node from crate workspace-tools",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/types/index.d.cts",

--- a/packages/workspace-tools/src/binding.d.ts
+++ b/packages/workspace-tools/src/binding.d.ts
@@ -522,6 +522,161 @@ export interface ChangesetDetailInfo {
 }
 
 /**
+ * Queries the changeset history with optional filtering.
+ *
+ * This function queries archived changesets from the workspace history,
+ * supporting various filter options for package, environment, bump type,
+ * date range, and result limit.
+ *
+ * # Parameters
+ *
+ * - `root`: Workspace root directory path (required)
+ * - `configPath`: Optional path to custom configuration file
+ * - `filterPackage`: Filter by package name
+ * - `filterEnv`: Filter by environment
+ * - `filterBump`: Filter by bump type (major, minor, patch)
+ * - `since`: Start date filter (ISO 8601 format)
+ * - `until`: End date filter (ISO 8601 format)
+ * - `limit`: Maximum number of results
+ *
+ * # Returns
+ *
+ * An `ApiResponse` containing `ChangesetHistoryData` with the list of archived
+ * changesets matching the query, or an error if the operation fails.
+ *
+ * ## Success Response
+ *
+ * ```typescript
+ * {
+ *   success: true,
+ *   data: {
+ *     archived: [
+ *       {
+ *         changeset: {
+ *           id: "feature/add-api",
+ *           branch: "feature/add-api",
+ *           bump: "minor",
+ *           packages: ["@scope/core"],
+ *           environments: ["production"],
+ *           commits: ["abc123"],
+ *           createdAt: "2024-01-15T10:30:00Z",
+ *           updatedAt: "2024-01-15T14:45:00Z"
+ *         },
+ *         releaseInfo: {
+ *           releasedAt: "2024-01-16T10:00:00Z",
+ *           releasedBy: "CI",
+ *           releaseCommit: "def456",
+ *           releasedVersions: [
+ *             { packageName: "@scope/core", version: "2.0.0" }
+ *           ]
+ *         }
+ *       }
+ *     ],
+ *     count: 1
+ *   }
+ * }
+ * ```
+ *
+ * ## Error Codes
+ *
+ * - `EVALIDATION`: Invalid parameters (empty root or invalid bump type)
+ * - `ENOENT`: Path not found
+ * - `ECONFIG`: Workspace not initialized
+ * - `EEXECUTION`: CLI command failed
+ *
+ * @example Basic usage - get all history
+ * ```typescript
+ * const result = await changesetHistory({
+ *   root: '/path/to/workspace'
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Found ${result.data.count} archived changesets`);
+ *   for (const item of result.data.archived) {
+ *     console.log(`- ${item.changeset.branch}: ${item.changeset.bump}`);
+ *     console.log(`  Released: ${item.releaseInfo.releasedAt}`);
+ *   }
+ * }
+ * ```
+ *
+ * @example Filter by package
+ * ```typescript
+ * const result = await changesetHistory({
+ *   root: '/path/to/workspace',
+ *   filterPackage: '@scope/core'
+ * });
+ *
+ * if (result.success) {
+ *   console.log(`Releases for @scope/core: ${result.data.count}`);
+ * }
+ * ```
+ *
+ * @example Filter by date range
+ * ```typescript
+ * const result = await changesetHistory({
+ *   root: '/path/to/workspace',
+ *   since: '2024-01-01',
+ *   until: '2024-12-31',
+ *   limit: 10
+ * });
+ * ```
+ *
+ * @example Filter by bump type
+ * ```typescript
+ * const result = await changesetHistory({
+ *   root: '/path/to/workspace',
+ *   filterBump: 'major'
+ * });
+ *
+ * if (result.success) {
+ *   console.log('Major releases:');
+ *   result.data.archived.forEach(item => {
+ *     const versions = item.releaseInfo.releasedVersions
+ *       .map(v => `${v.packageName}@${v.version}`)
+ *       .join(', ');
+ *     console.log(`  ${item.changeset.branch}: ${versions}`);
+ *   });
+ * }
+ * ```
+ *
+ * @example Multiple filters
+ * ```typescript
+ * const result = await changesetHistory({
+ *   root: '/path/to/workspace',
+ *   filterPackage: '@scope/core',
+ *   filterEnv: 'production',
+ *   filterBump: 'minor',
+ *   since: '2024-06-01',
+ *   limit: 5
+ * });
+ * ```
+ *
+ * @example Error handling
+ * ```typescript
+ * const result = await changesetHistory({
+ *   root: '/nonexistent/path'
+ * });
+ *
+ * if (!result.success) {
+ *   switch (result.error.code) {
+ *     case 'ENOENT':
+ *       console.error('Path not found');
+ *       break;
+ *     case 'EVALIDATION':
+ *       console.error('Invalid parameters:', result.error.message);
+ *       break;
+ *     case 'ECONFIG':
+ *       console.error('Workspace not initialized');
+ *       break;
+ *     default:
+ *       console.error(`Error: ${result.error.message}`);
+ *   }
+ * }
+ * ```
+ */
+export declare function changesetHistory(params: ChangesetHistoryParams): Promise<ChangesetHistoryApiResponse>
+
+/**
  * API response for the changeset history command.
  *
  * Wraps `ChangesetHistoryData` with success/error handling.

--- a/packages/workspace-tools/src/binding.js
+++ b/packages/workspace-tools/src/binding.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm-eabi')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-ia32-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-arm64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@websublime/workspace-tools-darwin-universal')
       const bindingPackageVersion = require('@websublime/workspace-tools-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-musleabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-ppc64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-s390x-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.0.6' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.6 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.8' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.8 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -573,6 +573,7 @@ if (!nativeBinding) {
 
 module.exports = nativeBinding
 module.exports.changesetAdd = nativeBinding.changesetAdd
+module.exports.changesetHistory = nativeBinding.changesetHistory
 module.exports.changesetList = nativeBinding.changesetList
 module.exports.changesetRemove = nativeBinding.changesetRemove
 module.exports.changesetShow = nativeBinding.changesetShow

--- a/packages/workspace-tools/src/index.ts
+++ b/packages/workspace-tools/src/index.ts
@@ -15,7 +15,8 @@
  * - `changesetList()` - List pending changesets with filtering (Story 4.4)
  * - `changesetShow()` - Show details of a specific changeset (Story 4.5)
  * - `changesetRemove()` - Remove a changeset from the workspace (Story 4.6)
- * - Changeset types for upcoming changeset commands (Stories 4.7-4.8)
+ * - `changesetHistory()` - Query archived changeset history (Story 4.7)
+ * - Changeset types for upcoming changeset commands (Story 4.8)
  *
  * ## How
  *
@@ -35,9 +36,9 @@
  */
 
 // Re-export all functions from bindings
-import { changesetAdd, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status } from './binding'
+import { changesetAdd, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status } from './binding'
 
-export { changesetAdd, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status }
+export { changesetAdd, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status }
 
 // Re-export all types from bindings
 export type {


### PR DESCRIPTION
- Add changesetHistory function to query archived changeset history
- Support all filter options: filterPackage, filterEnv, filterBump, since, until, limit
- Add CLI response types for parsing JSON output from execute_history
- Add conversion functions to map CLI types to NAPI types
- Add parameter validation for root path and bump type
- Add comprehensive tests (39 tests) for parsing, conversion, and validation
- Export changesetHistory in commands/mod.rs and lib.rs
- Update index.ts to re-export changesetHistory function
- Regenerate bindings with napi-rs

Story 4.7 implementation complete.