### PR TITLE
feat(WOR-TSK-197): add ARM64 Linux support for CLI binaries

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,6 +49,7 @@ jobs:
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
               - 'deny.toml'
+              - 'dist-workspace.toml'
               - '.gitattributes'
             node-changes:
               - *rust-changes

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -3,6 +3,12 @@
 //! A comprehensive command-line interface for managing Node.js workspaces and monorepos
 //! with changeset-based version management.
 //!
+//! ## Supported Platforms
+//!
+//! - macOS (Apple Silicon and Intel)
+//! - Linux (x64 glibc, x64 musl, ARM64 glibc)
+//! - Windows (x64)
+//!
 //! ## What
 //!
 //! This crate provides the `workspace` CLI tool that offers:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Allow manual modifications to CI workflow
 allow-dirty = ["ci"]
 


### PR DESCRIPTION
- Add aarch64-unknown-linux-gnu target to dist-workspace.toml
- Include dist-workspace.toml in pull-request.yml rust-changes filter
- Document supported platforms in CLI crate documentation