### PR TITLE
feat(WOR-TSK-192): implement bumpPreview NAPI function

### DIFF
--- a/crates/node/Cargo.lock
+++ b/crates/node/Cargo.lock
@@ -2067,7 +2067,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sublime_cli_tools"
-version = "0.0.28"
+version = "0.0.29"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -69,7 +69,7 @@ napi = { version = "3.6.0", features = ["async", "tokio_rt", "napi9", "serde-jso
 napi-derive = "3.4.0"
 
 # Workspace crates - using path dependencies
-sublime_cli_tools = { version = "0.0.28", path = "../cli" }
+sublime_cli_tools = { version = "0.0.29", path = "../cli" }
 sublime_git_tools = { version = "0.0.15", path = "../git" }
 sublime_pkg_tools = { version = "0.0.20", path = "../pkg" }
 sublime_standard_tools = { version = "0.0.15", path = "../standard" }

--- a/crates/node/src/commands/bump.rs
+++ b/crates/node/src/commands/bump.rs
@@ -10,15 +10,37 @@
 //!
 //! The module provides the following functions:
 //!
-//! - `bumpPreview`: Shows what versions would be bumped without making changes
-//! - `bumpApply`: Applies version bumps, updates dependencies, and optionally commits/tags
-//! - `bumpSnapshot`: Generates snapshot versions for pre-release testing
+//! - `bumpPreview`: Shows what versions would be bumped without making changes (Story 5.2)
+//! - `bumpApply`: Applies version bumps, updates dependencies, and optionally commits/tags (Story 5.3)
+//! - `bumpSnapshot`: Generates snapshot versions for pre-release testing (Story 5.4)
 //!
 //! Each function:
 //! 1. Validates the input parameters
 //! 2. Calls the appropriate `execute_*` function from `sublime_cli_tools`
-//! 3. Captures the JSON output
-//! 4. Returns a `JsonResponse<T>` with the result
+//! 3. Captures the JSON output using a `SharedBuffer`
+//! 4. Parses the JSON response using serde
+//! 5. Converts CLI types to NAPI-compatible types
+//! 6. Returns a typed `ApiResponse` with the result
+//!
+//! ## SharedBuffer Pattern
+//!
+//! The `Output` struct from the CLI crate takes ownership of the writer and doesn't
+//! expose an `into_inner()` method. To work around this limitation, we use a
+//! `SharedBuffer` that wraps `Arc<Mutex<Vec<u8>>>`:
+//!
+//! ```text
+//! SharedBuffer(Arc<Mutex<Vec<u8>>>)
+//!        │
+//!        ├── Clone → Output::new(..., SharedBuffer, ...)
+//!        │                    │
+//!        │                    ▼
+//!        │              write() calls
+//!        │                    │
+//!        │                    ▼
+//!        │              Arc<Mutex<Vec<u8>>> (shared)
+//!        │
+//!        └── After execution: extract bytes from Arc
+//! ```
 //!
 //! # Why
 //!
@@ -26,14 +48,18 @@
 //! provide fine-grained control over how versions are updated, including dry-run
 //! capabilities and git integration for automated releases.
 //!
+//! Key use cases:
+//! - Previewing version changes before applying them (CI/CD validation)
+//! - Applying version bumps with optional Git integration
+//! - Generating snapshot versions for pre-release testing
+//! - Supporting prerelease workflows (alpha, beta, rc)
+//!
 //! # Examples
 //!
+//! ## TypeScript Usage
+//!
 //! ```typescript
-//! import {
-//!   bumpPreview,
-//!   bumpApply,
-//!   bumpSnapshot
-//! } from '@websublime/workspace-tools';
+//! import { bumpPreview, bumpApply, bumpSnapshot } from '@websublime/workspace-tools';
 //!
 //! // Preview version bumps (dry run)
 //! const previewResult = await bumpPreview({
@@ -44,21 +70,20 @@
 //!   for (const pkg of previewResult.data.packages) {
 //!     console.log(`${pkg.name}: ${pkg.currentVersion} -> ${pkg.nextVersion} (${pkg.bump})`);
 //!   }
-//!   console.log(`\nDependency updates: ${previewResult.data.summary.dependenciesUpdated}`);
+//!   console.log(`\nTotal: ${previewResult.data.summary.totalPackages} packages`);
 //! }
 //!
 //! // Apply version bumps with git commit and tags
 //! const applyResult = await bumpApply({
 //!   root: '.',
-//!   execute: true,
 //!   gitCommit: true,
 //!   gitTag: true,
 //!   gitPush: false  // Don't push automatically
 //! });
 //! if (applyResult.success) {
-//!   console.log(`Applied ${applyResult.data.applied.length} version bumps`);
-//!   console.log(`Git commit: ${applyResult.data.gitCommitSha}`);
-//!   console.log(`Git tags: ${applyResult.data.gitTags.join(', ')}`);
+//!   console.log(`Applied ${applyResult.data.packagesUpdated} version bumps`);
+//!   console.log(`Git commit: ${applyResult.data.commitSha}`);
+//!   console.log(`Git tags: ${applyResult.data.tagsCreated.join(', ')}`);
 //! }
 //!
 //! // Generate snapshot versions for pre-release
@@ -72,58 +97,575 @@
 //!   }
 //! }
 //! ```
+//!
+//! ## Error Handling
+//!
+//! ```typescript
+//! const result = await bumpPreview({ root: '/nonexistent/path' });
+//!
+//! if (!result.success) {
+//!   switch (result.error.code) {
+//!     case 'ENOENT':
+//!       console.error('Path not found:', result.error.message);
+//!       break;
+//!     case 'EVALIDATION':
+//!       console.error('Invalid parameters:', result.error.message);
+//!       break;
+//!     default:
+//!       console.error('Unexpected error:', result.error.message);
+//!   }
+//! }
+//! ```
 
-// TODO: will be implemented on story 5.2-5.4 - Bump Commands
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use napi_derive::napi;
+use serde::Deserialize;
+
+use crate::error::ErrorInfo;
+use crate::types::bump::{
+    BumpPreviewApiResponse, BumpPreviewData, BumpPreviewParams, BumpSummaryInfo, PackageVersionInfo,
+};
+use crate::validation::validators;
+
+use sublime_cli_tools::cli::commands::BumpArgs;
+use sublime_cli_tools::commands::bump::execute_bump_preview;
+use sublime_cli_tools::output::{Output, OutputFormat};
+
+// ============================================================================
+// SharedBuffer - Output Capture Mechanism
+// ============================================================================
+
+/// A shared buffer wrapper for capturing CLI output.
+///
+/// The `Output` struct from `sublime_cli_tools` takes ownership of the writer
+/// and doesn't expose an `into_inner()` method. This wrapper uses `Arc<Mutex<Vec<u8>>>`
+/// to allow sharing the buffer between the caller and the Output, enabling
+/// extraction of the written bytes after command execution.
+///
+/// # Thread Safety
+///
+/// The buffer is protected by a `Mutex` to ensure safe concurrent access,
+/// although in typical usage the writes happen sequentially.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let buffer = SharedBuffer::new();
+/// let output = Output::new(OutputFormat::Json, buffer.clone(), true);
+///
+/// // ... execute command that writes to output ...
+///
+/// let bytes = buffer.take_bytes();
+/// ```
+#[derive(Debug, Clone)]
+pub(crate) struct SharedBuffer {
+    /// The inner buffer wrapped in `Arc<Mutex>` for shared ownership.
+    inner: Arc<Mutex<Vec<u8>>>,
+}
+
+impl SharedBuffer {
+    /// Creates a new empty shared buffer.
+    ///
+    /// # Returns
+    ///
+    /// A new `SharedBuffer` instance ready for use with `Output::new()`.
+    pub(crate) fn new() -> Self {
+        Self { inner: Arc::new(Mutex::new(Vec::new())) }
+    }
+
+    /// Extracts the bytes written to the buffer.
+    ///
+    /// This method clones the current buffer contents. The original buffer
+    /// remains intact for potential further writes.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<u8>` containing all bytes written to the buffer.
+    ///
+    /// # Panics
+    ///
+    /// This method will return an empty Vec if the mutex is poisoned,
+    /// rather than panicking, to maintain robustness.
+    pub(crate) fn take_bytes(&self) -> Vec<u8> {
+        match self.inner.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => {
+                // If the mutex is poisoned, still try to get the data
+                // This provides graceful degradation
+                poisoned.into_inner().clone()
+            }
+        }
+    }
+}
+
+impl Write for SharedBuffer {
+    /// Writes data to the shared buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `buf` - The byte slice to write
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes written, or an I/O error if the mutex is poisoned.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self.inner.lock() {
+            Ok(mut guard) => guard.write(buf),
+            Err(_) => Err(std::io::Error::other("Mutex poisoned")),
+        }
+    }
+
+    /// Flushes the buffer.
+    ///
+    /// Since `Vec<u8>` is an in-memory buffer, this is a no-op.
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+// Required for `Output::new()` which expects `Write + Send`
+// SAFETY: SharedBuffer uses Arc<Mutex<_>> which is Send + Sync
+unsafe impl Send for SharedBuffer {}
+
+// ============================================================================
+// CLI Response Types (for parsing JSON output)
+// ============================================================================
+
+/// CLI JSON response wrapper for bump preview command.
+///
+/// This type mirrors the `JsonResponse<T>` structure from the CLI crate,
+/// used for deserializing the captured JSON output.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliJsonResponse<T> {
+    /// Whether the operation succeeded.
+    pub(crate) success: bool,
+    /// The response data (present when success is true).
+    pub(crate) data: Option<T>,
+    /// Error message (present when success is false).
+    pub(crate) error: Option<String>,
+}
+
+/// CLI bump snapshot data structure.
+///
+/// Mirrors the `BumpSnapshot` structure from the CLI's bump command.
+/// Field names use camelCase to match the JSON output format.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliBumpSnapshot {
+    /// Versioning strategy being used (Independent or Unified).
+    pub(crate) strategy: String,
+    /// List of all workspace packages with their bump information.
+    pub(crate) packages: Vec<CliPackageBumpInfo>,
+    /// List of changesets being processed in this bump.
+    pub(crate) changesets: Vec<CliChangesetInfo>,
+    /// Summary statistics for the bump operation.
+    #[allow(dead_code)]
+    pub(crate) summary: CliBumpSummary,
+}
+
+/// CLI package bump information.
+///
+/// Mirrors the `PackageBumpInfo` structure from the CLI's bump command.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliPackageBumpInfo {
+    /// Package name (e.g., "@org/core").
+    pub(crate) name: String,
+    /// Relative path to package directory.
+    pub(crate) path: String,
+    /// Current version (e.g., "1.2.3").
+    pub(crate) current_version: String,
+    /// Next version after bump (e.g., "1.3.0").
+    pub(crate) next_version: String,
+    /// Type of version bump (Major, Minor, Patch, None).
+    pub(crate) bump_type: String,
+    /// Whether this package will actually be bumped.
+    pub(crate) will_bump: bool,
+    /// Human-readable reason for bump or no-bump.
+    #[allow(dead_code)]
+    pub(crate) reason: String,
+}
+
+/// CLI changeset information.
+///
+/// Mirrors the `ChangesetInfo` structure from the CLI's bump command.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliChangesetInfo {
+    /// Changeset ID.
+    pub(crate) id: String,
+    /// Git branch name.
+    #[allow(dead_code)]
+    pub(crate) branch: String,
+    /// Bump type for this changeset.
+    #[allow(dead_code)]
+    pub(crate) bump_type: String,
+    /// List of packages affected by this changeset.
+    #[allow(dead_code)]
+    pub(crate) packages: Vec<String>,
+    /// Number of commits in this changeset.
+    #[allow(dead_code)]
+    pub(crate) commit_count: usize,
+}
+
+/// CLI bump summary information.
+///
+/// Mirrors the `BumpSummary` structure from the CLI's bump command.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliBumpSummary {
+    /// Total number of packages in workspace.
+    #[allow(dead_code)]
+    pub(crate) total_packages: usize,
+    /// Number of packages that will be bumped.
+    #[allow(dead_code)]
+    pub(crate) packages_to_bump: usize,
+    /// Number of packages that won't be bumped.
+    #[allow(dead_code)]
+    pub(crate) packages_unchanged: usize,
+    /// Total number of changesets being processed.
+    #[allow(dead_code)]
+    pub(crate) total_changesets: usize,
+    /// Whether circular dependencies were detected.
+    #[allow(dead_code)]
+    pub(crate) has_circular_dependencies: bool,
+}
+
+// ============================================================================
+// Conversion Functions
+// ============================================================================
+
+/// Converts a bump type string to the NAPI-compatible format.
+///
+/// The CLI uses enum variants like "Major", "Minor", "Patch", "None",
+/// while the NAPI interface uses lowercase strings.
+///
+/// # Arguments
+///
+/// * `bump_type` - The bump type string from CLI (e.g., "Major", "Minor")
+///
+/// # Returns
+///
+/// A lowercase bump type string (e.g., "major", "minor", "patch", "none").
+fn normalize_bump_type(bump_type: &str) -> String {
+    bump_type.to_lowercase()
+}
+
+/// Converts CLI bump snapshot data to NAPI-compatible `BumpPreviewData`.
+///
+/// This function performs a conversion from the CLI's internal types to the
+/// NAPI types exposed to JavaScript, filtering to only include packages
+/// that will actually be bumped.
+///
+/// # Arguments
+///
+/// * `cli_data` - The parsed CLI response data
+///
+/// # Returns
+///
+/// A `BumpPreviewData` instance suitable for returning to JavaScript.
+pub(crate) fn convert_to_napi_preview(cli_data: CliBumpSnapshot) -> BumpPreviewData {
+    // Filter to only packages that will be bumped and convert to NAPI types
+    let packages: Vec<PackageVersionInfo> = cli_data
+        .packages
+        .into_iter()
+        .filter(|p| p.will_bump)
+        .map(|p| PackageVersionInfo {
+            name: p.name,
+            path: p.path,
+            current_version: p.current_version,
+            next_version: p.next_version,
+            bump: normalize_bump_type(&p.bump_type),
+            dependency_updates: Vec::new(), // Dependency updates not available in preview
+        })
+        .collect();
+
+    // Calculate summary from filtered packages
+    let summary = calculate_summary_from_packages(&packages);
+
+    // Extract just the changeset IDs
+    let changesets: Vec<String> = cli_data.changesets.into_iter().map(|c| c.id).collect();
+
+    BumpPreviewData { strategy: cli_data.strategy.to_lowercase(), packages, summary, changesets }
+}
+
+/// Calculates bump summary statistics from a list of packages.
+///
+/// # Arguments
+///
+/// * `packages` - The list of package version info
+///
+/// # Returns
+///
+/// A `BumpSummaryInfo` with counts of each bump type.
+#[allow(clippy::cast_possible_truncation)]
+// Justification: It's practically impossible to have more than 4 billion packages in a
+// workspace. The u32 limit of ~4.29 billion packages is sufficient for any real-world
+// monorepo. This truncation would only occur in an unrealistic edge case.
+fn calculate_summary_from_packages(packages: &[PackageVersionInfo]) -> BumpSummaryInfo {
+    let total_packages = packages.len() as u32;
+    let major_bumps = packages.iter().filter(|p| p.bump == "major").count() as u32;
+    let minor_bumps = packages.iter().filter(|p| p.bump == "minor").count() as u32;
+    let patch_bumps = packages.iter().filter(|p| p.bump == "patch").count() as u32;
+
+    BumpSummaryInfo { total_packages, major_bumps, minor_bumps, patch_bumps }
+}
+
+/// Parses the JSON response from the CLI and converts it to NAPI types.
+///
+/// # Arguments
+///
+/// * `json_bytes` - The raw JSON bytes captured from CLI output
+///
+/// # Returns
+///
+/// * `Ok(BumpPreviewData)` - Successfully parsed and converted preview data
+/// * `Err(ErrorInfo)` - Parsing failed or CLI returned an error
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The JSON is malformed or cannot be parsed
+/// - The CLI returned `success: false` with an error message
+/// - The CLI returned `success: true` but `data` is missing
+pub(crate) fn parse_preview_response(json_bytes: &[u8]) -> Result<BumpPreviewData, ErrorInfo> {
+    // Convert bytes to string first for better error messages
+    let json_str = std::str::from_utf8(json_bytes)
+        .map_err(|e| ErrorInfo::execution(format!("Invalid UTF-8 in CLI response: {e}")))?;
+
+    // Handle empty response
+    if json_str.trim().is_empty() {
+        return Err(ErrorInfo::execution("CLI returned empty response"));
+    }
+
+    // Parse the JSON response
+    let response: CliJsonResponse<CliBumpSnapshot> =
+        serde_json::from_str(json_str).map_err(|e| {
+            ErrorInfo::execution(format!(
+                "Failed to parse CLI JSON response: {e} (length={})",
+                json_str.len()
+            ))
+        })?;
+
+    // Check for CLI-level errors
+    if !response.success {
+        let error_message = response.error.unwrap_or_else(|| "Unknown CLI error".to_string());
+        return Err(ErrorInfo::execution(error_message));
+    }
+
+    // Extract and convert data
+    let cli_data =
+        response.data.ok_or_else(|| ErrorInfo::execution("CLI returned success but no data"))?;
+
+    Ok(convert_to_napi_preview(cli_data))
+}
+
+// ============================================================================
+// Parameter Validation
+// ============================================================================
+
+/// Validates bump preview command parameters.
+///
+/// Ensures the root path is valid before executing the CLI command.
+///
+/// # Arguments
+///
+/// * `params` - The preview parameters to validate
+///
+/// # Returns
+///
+/// * `Ok(PathBuf)` - The validated root path
+/// * `Err(ErrorInfo)` - Validation failed
+pub(crate) fn validate_preview_params(params: &BumpPreviewParams) -> Result<PathBuf, ErrorInfo> {
+    // Validate root path exists and is a directory
+    validators::root(&params.root)?;
+
+    Ok(PathBuf::from(&params.root))
+}
+
+/// Converts `BumpPreviewParams` to CLI `BumpArgs`.
+///
+/// This function sets the appropriate flags for preview mode (dry_run = true)
+/// and maps the NAPI parameters to CLI arguments.
+///
+/// # Arguments
+///
+/// * `params` - The NAPI preview parameters
+///
+/// # Returns
+///
+/// A `BumpArgs` struct configured for preview mode.
+pub(crate) fn convert_params_to_args(params: &BumpPreviewParams) -> BumpArgs {
+    BumpArgs {
+        // Preview mode: dry_run = true, no execution
+        dry_run: true,
+        execute: false,
+        snapshot: false,
+        snapshot_format: None,
+        prerelease: None,
+
+        // Package filter from params
+        packages: params.packages.clone(),
+
+        // No git operations in preview mode
+        git_tag: false,
+        git_push: false,
+        git_commit: false,
+
+        // No changelog/archive changes in preview
+        no_changelog: true,
+        no_archive: true,
+        always_archive: false,
+
+        // Skip confirmations (API is non-interactive)
+        force: true,
+
+        // Show diff from params
+        show_diff: params.show_diff.unwrap_or(false),
+    }
+}
+
+// ============================================================================
+// NAPI Functions
+// ============================================================================
+
+/// Preview version bumps without applying changes.
+///
+/// Returns comprehensive information about what versions would change based on
+/// pending changesets. This is a dry-run operation that does not modify any files.
+///
+/// This function is the main entry point for Node.js applications to preview
+/// version bumps. It handles all the complexity of CLI invocation and response
+/// parsing internally.
+///
+/// @param params - Preview parameters containing:
+///   - `root`: Workspace root directory path (required)
+///   - `configPath`: Optional custom config file path
+///   - `packages`: Optional filter to specific packages
+///   - `showDiff`: Whether to show detailed version diffs
+///
+/// @returns `Promise<ApiResponse<BumpPreviewData>>` containing:
+///   - On success: `{ success: true, data: BumpPreviewData }`
+///   - On failure: `{ success: false, error: ErrorInfo }`
+///
+/// @example Basic usage
+/// ```typescript
+/// const result = await bumpPreview({ root: '/path/to/project' });
+/// if (result.success) {
+///   console.log(`Strategy: ${result.data.strategy}`);
+///   console.log(`Packages to bump: ${result.data.packages.length}`);
+///   for (const pkg of result.data.packages) {
+///     console.log(`  ${pkg.name}: ${pkg.currentVersion} -> ${pkg.nextVersion}`);
+///   }
+/// } else {
+///   console.error(`Error: ${result.error.code} - ${result.error.message}`);
+/// }
+/// ```
+///
+/// @example With package filter and diff
+/// ```typescript
+/// const result = await bumpPreview({
+///   root: '/path/to/project',
+///   packages: ['@scope/core', '@scope/utils'],
+///   showDiff: true
+/// });
+/// ```
+///
+/// @example Error handling
+/// ```typescript
+/// const result = await bumpPreview({ root: '/nonexistent' });
+/// if (!result.success) {
+///   if (result.error.code === 'ENOENT') {
+///     console.error('Path not found');
+///   } else if (result.error.code === 'EVALIDATION') {
+///     console.error('Invalid parameters');
+///   }
+/// }
+/// ```
+#[napi(js_name = "bumpPreview")]
+pub async fn bump_preview(params: BumpPreviewParams) -> BumpPreviewApiResponse {
+    // 1. Validate parameters (synchronous validation before spawning)
+    let root_path = match validate_preview_params(&params) {
+        Ok(path) => path,
+        Err(error) => return BumpPreviewApiResponse::failure(error),
+    };
+
+    // 2. Prepare config path
+    let config_path: Option<PathBuf> = params.config_path.as_ref().map(PathBuf::from);
+
+    // 3. Convert params to CLI args
+    let args = convert_params_to_args(&params);
+
+    // 4. Execute CLI command in a blocking task
+    // The CLI's execute_bump_preview uses types that are not Send/Sync (RefCell, git2::Repository),
+    // so we must run it on a blocking thread via spawn_blocking.
+    let result = tokio::task::spawn_blocking(move || {
+        // Create a new tokio runtime for the blocking context
+        // This is necessary because execute_bump_preview is async but we're in a blocking context
+        let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                return Err(ErrorInfo::execution(format!("Failed to create runtime: {e}")));
+            }
+        };
+
+        rt.block_on(async {
+            // Create shared buffer for output capture
+            let buffer = SharedBuffer::new();
+
+            // Create Output with JSON format
+            let output = Output::new(OutputFormat::Json, buffer.clone(), true);
+
+            // Execute the CLI command
+            let config_path_ref: Option<&Path> = config_path.as_deref();
+            if let Err(cli_error) =
+                execute_bump_preview(&args, &output, &root_path, config_path_ref).await
+            {
+                return Err(ErrorInfo::from(cli_error));
+            }
+
+            // Extract and parse JSON
+            let json_bytes = buffer.take_bytes();
+            parse_preview_response(&json_bytes)
+        })
+    })
+    .await;
+
+    // 5. Handle spawn_blocking result
+    match result {
+        Ok(Ok(data)) => BumpPreviewApiResponse::success(data),
+        Ok(Err(error)) => BumpPreviewApiResponse::failure(error),
+        Err(join_error) => BumpPreviewApiResponse::failure(ErrorInfo::execution(format!(
+            "Task execution failed: {join_error}"
+        ))),
+    }
+}
+
+// TODO: will be implemented on story 5.3 - bumpApply
 //
-// Implementation outline for bumpPreview:
-//
-// #[napi]
-// pub async fn bump_preview(params: BumpPreviewParams) -> JsonResponse<BumpPreviewData> {
-//     // 1. Validate parameters
-//     if let Err(e) = validate_root(&params.root) {
-//         return JsonResponse::from_error_info(e);
-//     }
-//
-//     // 2. Create BumpArgs from params (with dry_run = true implicitly)
-//     // 3. Create Output with JSON format for capturing
-//     // 4. Call execute_bump_preview from CLI (commands/bump/preview.rs)
-//     // 5. Parse JSON response containing packages, dependency updates, summary
-//     // 6. Return JsonResponse::success(data) or JsonResponse::error(msg)
+// #[napi(js_name = "bumpApply")]
+// pub async fn bump_apply(params: BumpApplyParams) -> BumpApplyApiResponse {
+//     // Implementation will include:
+//     // 1. Validate parameters including prerelease tag if provided
+//     // 2. Create BumpArgs with execute = true
+//     // 3. Support git operations (commit, tag, push)
+//     // 4. Support prerelease parameter for alpha/beta/rc versions
+//     // 5. Support changelog/archive control
+//     // 6. Execute CLI command and parse response
+//     todo!()
 // }
+
+// TODO: will be implemented on story 5.4 - bumpSnapshot
 //
-// Implementation outline for bumpApply:
-//
-// #[napi]
-// pub async fn bump_apply(params: BumpApplyParams) -> JsonResponse<BumpApplyData> {
-//     // 1. Validate parameters
-//     if let Err(e) = validate_root(&params.root) {
-//         return JsonResponse::from_error_info(e);
-//     }
-//
-//     // 2. Create BumpArgs from params
-//     //    - execute: whether to actually write changes
-//     //    - git_commit: whether to create a git commit
-//     //    - git_tag: whether to create git tags
-//     //    - git_push: whether to push to remote
-//     // 3. Create Output with JSON format for capturing
-//     // 4. Call execute_bump_apply from CLI (commands/bump/execute.rs)
-//     // 5. Parse JSON response containing applied packages, git info, summary
-//     // 6. Return JsonResponse::success(data) or JsonResponse::error(msg)
-// }
-//
-// Implementation outline for bumpSnapshot:
-//
-// #[napi]
-// pub async fn bump_snapshot(params: BumpSnapshotParams) -> JsonResponse<BumpSnapshotData> {
-//     // 1. Validate parameters
-//     if let Err(e) = validate_root(&params.root) {
-//         return JsonResponse::from_error_info(e);
-//     }
-//
-//     // 2. Create BumpArgs from params with snapshot mode
-//     //    - format: snapshot version format template
-//     // 3. Create Output with JSON format for capturing
-//     // 4. Call execute_bump_snapshot from CLI (commands/bump/snapshot.rs)
-//     // 5. Parse JSON response containing packages with snapshot versions
-//     // 6. Return JsonResponse::success(data) or JsonResponse::error(msg)
+// #[napi(js_name = "bumpSnapshot")]
+// pub async fn bump_snapshot(params: BumpSnapshotParams) -> BumpSnapshotApiResponse {
+//     // Implementation will include:
+//     // 1. Validate parameters including snapshot format if provided
+//     // 2. Create BumpArgs with snapshot = true
+//     // 3. Execute CLI command and parse response
+//     // 4. Return snapshot version information
+//     todo!()
 // }

--- a/crates/node/src/commands/mod.rs
+++ b/crates/node/src/commands/mod.rs
@@ -88,8 +88,14 @@ mod tests;
 // TODO: will be implemented on story 7.2-7.3 (config commands)
 pub(crate) mod config;
 
-// TODO: will be implemented on story 5.2-5.4 (bump commands)
+// Bump commands - Story 5.2-5.4
 pub(crate) mod bump;
+
+// Re-export bump functions for lib.rs
+// Story 5.2: bumpPreview
+pub use bump::bump_preview;
+// TODO: will be implemented on story 5.3 (bumpApply)
+// TODO: will be implemented on story 5.4 (bumpSnapshot)
 
 // TODO: will be implemented on story 8.2-8.4 (upgrade commands)
 pub(crate) mod upgrade;

--- a/crates/node/src/commands/tests.rs
+++ b/crates/node/src/commands/tests.rs
@@ -4141,3 +4141,692 @@ mod changeset_check_tests {
         }
     }
 }
+
+// ============================================================================
+// Bump Preview Command Tests (Story 5.2)
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod bump_preview_tests {
+    use std::io::Write;
+
+    use tempfile::TempDir;
+
+    use crate::commands::bump::{
+        CliBumpSnapshot, CliBumpSummary, CliChangesetInfo, CliPackageBumpInfo, SharedBuffer,
+        convert_params_to_args, convert_to_napi_preview, parse_preview_response,
+        validate_preview_params,
+    };
+    use crate::types::bump::BumpPreviewParams;
+
+    // -------------------------------------------------------------------------
+    // SharedBuffer Tests
+    // -------------------------------------------------------------------------
+
+    mod shared_buffer_tests {
+        use super::*;
+
+        #[test]
+        fn test_shared_buffer_new() {
+            let buffer = SharedBuffer::new();
+            assert!(buffer.take_bytes().is_empty());
+        }
+
+        #[test]
+        fn test_shared_buffer_write() {
+            let mut buffer = SharedBuffer::new();
+            let bytes_written = buffer.write(b"hello").unwrap();
+            assert_eq!(bytes_written, 5);
+            assert_eq!(buffer.take_bytes(), b"hello");
+        }
+
+        #[test]
+        fn test_shared_buffer_multiple_writes() {
+            let mut buffer = SharedBuffer::new();
+            buffer.write_all(b"hello ").unwrap();
+            buffer.write_all(b"world").unwrap();
+            assert_eq!(buffer.take_bytes(), b"hello world");
+        }
+
+        #[test]
+        fn test_shared_buffer_clone_shares_data() {
+            let mut buffer = SharedBuffer::new();
+            let buffer_clone = buffer.clone();
+            buffer.write_all(b"shared data").unwrap();
+
+            // Both buffers should see the same data
+            assert_eq!(buffer.take_bytes(), b"shared data");
+            assert_eq!(buffer_clone.take_bytes(), b"shared data");
+        }
+
+        #[test]
+        fn test_shared_buffer_flush() {
+            let mut buffer = SharedBuffer::new();
+            assert!(buffer.flush().is_ok());
+        }
+
+        #[test]
+        fn test_shared_buffer_take_bytes_preserves_data() {
+            let mut buffer = SharedBuffer::new();
+            buffer.write_all(b"test data").unwrap();
+
+            // Multiple takes should return same data
+            let first_take = buffer.take_bytes();
+            let second_take = buffer.take_bytes();
+            assert_eq!(first_take, second_take);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Parse Response Tests
+    // -------------------------------------------------------------------------
+
+    mod parse_response_tests {
+        use super::*;
+
+        #[test]
+        fn test_parse_preview_response_success() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "strategy": "Independent",
+                    "packages": [
+                        {
+                            "name": "@scope/core",
+                            "path": "packages/core",
+                            "currentVersion": "1.0.0",
+                            "nextVersion": "1.1.0",
+                            "bumpType": "Minor",
+                            "willBump": true,
+                            "reason": "direct change from changeset"
+                        }
+                    ],
+                    "changesets": [
+                        {
+                            "id": "feature-new-api",
+                            "branch": "feature/new-api",
+                            "bumpType": "Minor",
+                            "packages": ["@scope/core"],
+                            "commitCount": 5
+                        }
+                    ],
+                    "summary": {
+                        "totalPackages": 1,
+                        "packagesToBump": 1,
+                        "packagesUnchanged": 0,
+                        "totalChangesets": 1,
+                        "hasCircularDependencies": false
+                    }
+                }
+            }"#;
+
+            let result = parse_preview_response(json.as_bytes());
+            assert!(result.is_ok());
+            let data = result.unwrap();
+            assert_eq!(data.strategy, "independent");
+            assert_eq!(data.packages.len(), 1);
+            assert_eq!(data.packages[0].name, "@scope/core");
+            assert_eq!(data.packages[0].current_version, "1.0.0");
+            assert_eq!(data.packages[0].next_version, "1.1.0");
+            assert_eq!(data.packages[0].bump, "minor");
+            assert_eq!(data.changesets.len(), 1);
+            assert_eq!(data.changesets[0], "feature-new-api");
+            assert_eq!(data.summary.total_packages, 1);
+            assert_eq!(data.summary.minor_bumps, 1);
+        }
+
+        #[test]
+        fn test_parse_preview_response_no_packages_to_bump() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "strategy": "Unified",
+                    "packages": [
+                        {
+                            "name": "@scope/utils",
+                            "path": "packages/utils",
+                            "currentVersion": "2.0.0",
+                            "nextVersion": "2.0.0",
+                            "bumpType": "None",
+                            "willBump": false,
+                            "reason": "not in any changeset"
+                        }
+                    ],
+                    "changesets": [],
+                    "summary": {
+                        "totalPackages": 1,
+                        "packagesToBump": 0,
+                        "packagesUnchanged": 1,
+                        "totalChangesets": 0,
+                        "hasCircularDependencies": false
+                    }
+                }
+            }"#;
+
+            let result = parse_preview_response(json.as_bytes());
+            assert!(result.is_ok());
+            let data = result.unwrap();
+            assert_eq!(data.strategy, "unified");
+            // Packages with willBump=false are filtered out
+            assert_eq!(data.packages.len(), 0);
+            assert_eq!(data.changesets.len(), 0);
+            assert_eq!(data.summary.total_packages, 0);
+        }
+
+        #[test]
+        fn test_parse_preview_response_multiple_bump_types() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "strategy": "Independent",
+                    "packages": [
+                        {
+                            "name": "@scope/core",
+                            "path": "packages/core",
+                            "currentVersion": "1.0.0",
+                            "nextVersion": "2.0.0",
+                            "bumpType": "Major",
+                            "willBump": true,
+                            "reason": "breaking change"
+                        },
+                        {
+                            "name": "@scope/utils",
+                            "path": "packages/utils",
+                            "currentVersion": "1.0.0",
+                            "nextVersion": "1.1.0",
+                            "bumpType": "Minor",
+                            "willBump": true,
+                            "reason": "new feature"
+                        },
+                        {
+                            "name": "@scope/config",
+                            "path": "packages/config",
+                            "currentVersion": "1.0.0",
+                            "nextVersion": "1.0.1",
+                            "bumpType": "Patch",
+                            "willBump": true,
+                            "reason": "bug fix"
+                        }
+                    ],
+                    "changesets": [],
+                    "summary": {
+                        "totalPackages": 3,
+                        "packagesToBump": 3,
+                        "packagesUnchanged": 0,
+                        "totalChangesets": 1,
+                        "hasCircularDependencies": false
+                    }
+                }
+            }"#;
+
+            let result = parse_preview_response(json.as_bytes());
+            assert!(result.is_ok());
+            let data = result.unwrap();
+            assert_eq!(data.packages.len(), 3);
+            assert_eq!(data.summary.total_packages, 3);
+            assert_eq!(data.summary.major_bumps, 1);
+            assert_eq!(data.summary.minor_bumps, 1);
+            assert_eq!(data.summary.patch_bumps, 1);
+        }
+
+        #[test]
+        fn test_parse_preview_response_cli_error() {
+            let json = r#"{
+                "success": false,
+                "error": "No changesets found"
+            }"#;
+
+            let result = parse_preview_response(json.as_bytes());
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EEXEC");
+            assert!(error.message.contains("No changesets found"));
+        }
+
+        #[test]
+        fn test_parse_preview_response_empty() {
+            let result = parse_preview_response(b"");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("empty response"));
+        }
+
+        #[test]
+        fn test_parse_preview_response_whitespace_only() {
+            let result = parse_preview_response(b"   \n  \t  ");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("empty response"));
+        }
+
+        #[test]
+        fn test_parse_preview_response_invalid_json() {
+            let result = parse_preview_response(b"not valid json");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Failed to parse"));
+        }
+
+        #[test]
+        fn test_parse_preview_response_invalid_utf8() {
+            let invalid_utf8 = vec![0xFF, 0xFE, 0x00, 0x01];
+            let result = parse_preview_response(&invalid_utf8);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Invalid UTF-8"));
+        }
+
+        #[test]
+        fn test_parse_preview_response_success_no_data() {
+            let json = r#"{"success": true}"#;
+            let result = parse_preview_response(json.as_bytes());
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("no data"));
+        }
+
+        #[test]
+        fn test_parse_preview_response_cli_error_no_message() {
+            let json = r#"{"success": false}"#;
+            let result = parse_preview_response(json.as_bytes());
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Unknown CLI error"));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Conversion Tests
+    // -------------------------------------------------------------------------
+
+    mod conversion_tests {
+        use super::*;
+
+        #[test]
+        fn test_convert_to_napi_preview_full() {
+            let cli_data = CliBumpSnapshot {
+                strategy: "Independent".to_string(),
+                packages: vec![
+                    CliPackageBumpInfo {
+                        name: "@scope/core".to_string(),
+                        path: "packages/core".to_string(),
+                        current_version: "1.0.0".to_string(),
+                        next_version: "2.0.0".to_string(),
+                        bump_type: "Major".to_string(),
+                        will_bump: true,
+                        reason: "breaking change".to_string(),
+                    },
+                    CliPackageBumpInfo {
+                        name: "@scope/utils".to_string(),
+                        path: "packages/utils".to_string(),
+                        current_version: "1.0.0".to_string(),
+                        next_version: "1.0.0".to_string(),
+                        bump_type: "None".to_string(),
+                        will_bump: false,
+                        reason: "not in changeset".to_string(),
+                    },
+                ],
+                changesets: vec![CliChangesetInfo {
+                    id: "feature-breaking".to_string(),
+                    branch: "feature/breaking".to_string(),
+                    bump_type: "Major".to_string(),
+                    packages: vec!["@scope/core".to_string()],
+                    commit_count: 3,
+                }],
+                summary: CliBumpSummary {
+                    total_packages: 2,
+                    packages_to_bump: 1,
+                    packages_unchanged: 1,
+                    total_changesets: 1,
+                    has_circular_dependencies: false,
+                },
+            };
+
+            let result = convert_to_napi_preview(cli_data);
+
+            // Strategy should be lowercase
+            assert_eq!(result.strategy, "independent");
+
+            // Only packages with will_bump=true should be included
+            assert_eq!(result.packages.len(), 1);
+            assert_eq!(result.packages[0].name, "@scope/core");
+            assert_eq!(result.packages[0].bump, "major");
+
+            // Changesets should only have IDs
+            assert_eq!(result.changesets.len(), 1);
+            assert_eq!(result.changesets[0], "feature-breaking");
+
+            // Summary should be calculated from filtered packages
+            assert_eq!(result.summary.total_packages, 1);
+            assert_eq!(result.summary.major_bumps, 1);
+            assert_eq!(result.summary.minor_bumps, 0);
+            assert_eq!(result.summary.patch_bumps, 0);
+        }
+
+        #[test]
+        fn test_convert_to_napi_preview_empty() {
+            let cli_data = CliBumpSnapshot {
+                strategy: "Unified".to_string(),
+                packages: vec![],
+                changesets: vec![],
+                summary: CliBumpSummary {
+                    total_packages: 0,
+                    packages_to_bump: 0,
+                    packages_unchanged: 0,
+                    total_changesets: 0,
+                    has_circular_dependencies: false,
+                },
+            };
+
+            let result = convert_to_napi_preview(cli_data);
+            assert_eq!(result.strategy, "unified");
+            assert!(result.packages.is_empty());
+            assert!(result.changesets.is_empty());
+            assert_eq!(result.summary.total_packages, 0);
+        }
+
+        #[test]
+        fn test_convert_params_to_args_defaults() {
+            let params = BumpPreviewParams::new("/path/to/project");
+            let args = convert_params_to_args(&params);
+
+            // Preview mode settings
+            assert!(args.dry_run);
+            assert!(!args.execute);
+            assert!(!args.snapshot);
+
+            // Default values
+            assert!(args.packages.is_none());
+            assert!(!args.show_diff);
+            assert!(args.force);
+
+            // No git operations
+            assert!(!args.git_commit);
+            assert!(!args.git_tag);
+            assert!(!args.git_push);
+
+            // No changelog/archive in preview
+            assert!(args.no_changelog);
+            assert!(args.no_archive);
+        }
+
+        #[test]
+        fn test_convert_params_to_args_with_options() {
+            let params = BumpPreviewParams::new("/path/to/project")
+                .with_packages(vec!["@scope/core".to_string(), "@scope/utils".to_string()])
+                .with_show_diff(true);
+            let args = convert_params_to_args(&params);
+
+            assert!(args.dry_run);
+            assert_eq!(
+                args.packages,
+                Some(vec!["@scope/core".to_string(), "@scope/utils".to_string()])
+            );
+            assert!(args.show_diff);
+        }
+
+        #[test]
+        fn test_convert_params_to_args_show_diff_false() {
+            let params = BumpPreviewParams::new("/path/to/project").with_show_diff(false);
+            let args = convert_params_to_args(&params);
+            assert!(!args.show_diff);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation Tests
+    // -------------------------------------------------------------------------
+
+    mod validation_tests {
+        use super::*;
+
+        #[test]
+        fn test_validate_preview_params_valid_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpPreviewParams::new(path_str);
+            let result = validate_preview_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_preview_params_nonexistent_path() {
+            let params = BumpPreviewParams::new("/nonexistent/path/to/project");
+            let result = validate_preview_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "ENOENT");
+        }
+
+        #[test]
+        fn test_validate_preview_params_empty_root() {
+            let params = BumpPreviewParams::new("");
+            let result = validate_preview_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+        }
+
+        #[test]
+        fn test_validate_preview_params_file_not_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let file_path = temp_dir.path().join("test.txt");
+            std::fs::write(&file_path, "test content").unwrap();
+
+            let params = BumpPreviewParams::new(file_path.to_str().unwrap());
+            let result = validate_preview_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+        }
+
+        #[test]
+        fn test_validate_preview_params_with_packages() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params =
+                BumpPreviewParams::new(path_str).with_packages(vec!["@scope/core".to_string()]);
+            let result = validate_preview_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_preview_params_with_config_path() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpPreviewParams::new(path_str).with_config_path("/path/to/config.json");
+            let result = validate_preview_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_preview_params_returns_correct_path() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpPreviewParams::new(path_str);
+            let result = validate_preview_params(&params);
+            assert!(result.is_ok());
+            let path = result.unwrap();
+            assert_eq!(path.to_str().unwrap(), path_str);
+        }
+    }
+}
+
+// ============================================================================
+// Validator Tests for Bump Commands (Story 5.2-5.4)
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod bump_validator_tests {
+    use crate::validation::validators;
+
+    // -------------------------------------------------------------------------
+    // Prerelease Tag Validator Tests
+    // -------------------------------------------------------------------------
+
+    mod prerelease_tag_tests {
+        use super::*;
+
+        #[test]
+        fn test_prerelease_tag_valid_alpha() {
+            let result = validators::prerelease_tag("alpha");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_prerelease_tag_valid_beta() {
+            let result = validators::prerelease_tag("beta");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_prerelease_tag_valid_rc() {
+            let result = validators::prerelease_tag("rc");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_prerelease_tag_valid_with_numbers() {
+            let result = validators::prerelease_tag("beta1");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_prerelease_tag_valid_with_hyphen() {
+            let result = validators::prerelease_tag("beta-1");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_prerelease_tag_valid_uppercase() {
+            let result = validators::prerelease_tag("RC1");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_prerelease_tag_valid_mixed_case() {
+            let result = validators::prerelease_tag("Alpha-2");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_prerelease_tag_empty() {
+            let result = validators::prerelease_tag("");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("cannot be empty"));
+        }
+
+        #[test]
+        fn test_prerelease_tag_invalid_period() {
+            let result = validators::prerelease_tag("alpha.1");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("invalid characters"));
+        }
+
+        #[test]
+        fn test_prerelease_tag_invalid_underscore() {
+            let result = validators::prerelease_tag("beta_1");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("invalid characters"));
+        }
+
+        #[test]
+        fn test_prerelease_tag_invalid_space() {
+            let result = validators::prerelease_tag("beta 1");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("invalid characters"));
+        }
+
+        #[test]
+        fn test_prerelease_tag_invalid_special_chars() {
+            let result = validators::prerelease_tag("alpha@1");
+            assert!(result.is_err());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Snapshot Format Validator Tests
+    // -------------------------------------------------------------------------
+
+    mod snapshot_format_tests {
+        use super::*;
+
+        #[test]
+        fn test_snapshot_format_valid_default() {
+            let result = validators::snapshot_format("{version}-snapshot.{short_commit}");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_snapshot_format_valid_with_branch() {
+            let result = validators::snapshot_format("{version}-{branch}.{short_commit}");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_snapshot_format_valid_with_timestamp() {
+            let result = validators::snapshot_format("{version}-dev.{timestamp}");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_snapshot_format_valid_with_commit() {
+            let result = validators::snapshot_format("{version}-{commit}");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_snapshot_format_valid_version_only() {
+            let result = validators::snapshot_format("{version}");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_snapshot_format_valid_all_variables() {
+            let result = validators::snapshot_format(
+                "{version}-{branch}-{short_commit}-{commit}-{timestamp}",
+            );
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_snapshot_format_empty() {
+            let result = validators::snapshot_format("");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("cannot be empty"));
+        }
+
+        #[test]
+        fn test_snapshot_format_no_variables() {
+            let result = validators::snapshot_format("no-variables-here");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("must contain at least one"));
+        }
+
+        #[test]
+        fn test_snapshot_format_invalid_variable() {
+            let result = validators::snapshot_format("{invalid}");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("must contain at least one"));
+        }
+
+        #[test]
+        fn test_snapshot_format_partial_variable_name() {
+            let result = validators::snapshot_format("{ver}-{bran}");
+            assert!(result.is_err());
+        }
+    }
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -151,7 +151,13 @@ pub use commands::changeset_remove;
 pub use commands::changeset_history;
 // Story 4.8: changesetCheck
 pub use commands::changeset_check;
-// TODO: will be implemented on story 5.2-5.4 (bump commands)
+
+// Bump commands (Story 5.2-5.4)
+// Story 5.2: bumpPreview
+pub use commands::bump_preview;
+// TODO: will be implemented on story 5.3 (bumpApply)
+// TODO: will be implemented on story 5.4 (bumpSnapshot)
+
 // TODO: will be implemented on story 6.3 (execute command)
 // TODO: will be implemented on story 7.2-7.3 (config commands)
 // TODO: will be implemented on story 8.2-8.4 (upgrade commands)

--- a/crates/node/src/validation.rs
+++ b/crates/node/src/validation.rs
@@ -839,4 +839,126 @@ pub(crate) mod validators {
         }
         Ok(())
     }
+
+    /// Validates a prerelease tag.
+    ///
+    /// Valid tags contain only ASCII alphanumerics and hyphens `[0-9A-Za-z-]`,
+    /// as per SemVer 2.0.0 specification.
+    ///
+    /// # Arguments
+    ///
+    /// * `tag` - The prerelease tag to validate
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` if the tag is valid
+    /// * `Err(ErrorInfo)` if the tag is empty or contains invalid characters
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::validation::validators;
+    ///
+    /// // Valid prerelease tags
+    /// assert!(validators::prerelease_tag("alpha").is_ok());
+    /// assert!(validators::prerelease_tag("beta").is_ok());
+    /// assert!(validators::prerelease_tag("rc").is_ok());
+    /// assert!(validators::prerelease_tag("beta-1").is_ok());
+    /// assert!(validators::prerelease_tag("RC1").is_ok());
+    ///
+    /// // Invalid prerelease tags
+    /// assert!(validators::prerelease_tag("").is_err());
+    /// assert!(validators::prerelease_tag("alpha.1").is_err());  // Contains period
+    /// assert!(validators::prerelease_tag("beta_1").is_err());   // Contains underscore
+    /// ```
+    pub fn prerelease_tag(tag: &str) -> ValidationResult<()> {
+        if tag.is_empty() {
+            return Err(ErrorInfo::validation(
+                "prerelease tag cannot be empty",
+                Some("prerelease"),
+            ));
+        }
+
+        // Check for valid characters (SemVer 2.0.0 spec: [0-9A-Za-z-])
+        if !tag.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            return Err(ErrorInfo::validation(
+                format!(
+                    "prerelease tag '{tag}' contains invalid characters. \
+                     Must contain only ASCII alphanumerics and hyphens [0-9A-Za-z-]"
+                ),
+                Some("prerelease"),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Valid snapshot format template variables.
+    ///
+    /// These are the variables that can be used in snapshot format templates:
+    /// - `{version}`: Current package version
+    /// - `{branch}`: Current Git branch name (sanitized)
+    /// - `{short_commit}`: Short Git commit hash (7 characters)
+    /// - `{commit}`: Full Git commit hash
+    /// - `{timestamp}`: Unix timestamp
+    pub const VALID_SNAPSHOT_VARIABLES: &[&str] =
+        &["{version}", "{branch}", "{short_commit}", "{commit}", "{timestamp}"];
+
+    /// Validates a snapshot format template.
+    ///
+    /// A valid snapshot format must contain at least one valid template variable.
+    ///
+    /// # Valid Variables
+    ///
+    /// - `{version}`: Current package version
+    /// - `{branch}`: Current Git branch name (sanitized)
+    /// - `{short_commit}`: Short Git commit hash (7 characters)
+    /// - `{commit}`: Full Git commit hash
+    /// - `{timestamp}`: Unix timestamp
+    ///
+    /// # Arguments
+    ///
+    /// * `format` - The snapshot format template to validate
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` if the format is valid
+    /// * `Err(ErrorInfo)` if the format is empty or contains no valid variables
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::validation::validators;
+    ///
+    /// // Valid snapshot formats
+    /// assert!(validators::snapshot_format("{version}-snapshot.{short_commit}").is_ok());
+    /// assert!(validators::snapshot_format("{version}-{branch}.{commit}").is_ok());
+    /// assert!(validators::snapshot_format("{version}-dev.{timestamp}").is_ok());
+    ///
+    /// // Invalid snapshot formats
+    /// assert!(validators::snapshot_format("").is_err());
+    /// assert!(validators::snapshot_format("no-variables-here").is_err());
+    /// assert!(validators::snapshot_format("{invalid}").is_err());
+    /// ```
+    pub fn snapshot_format(format: &str) -> ValidationResult<()> {
+        if format.is_empty() {
+            return Err(ErrorInfo::validation("snapshot format cannot be empty", Some("format")));
+        }
+
+        // Check for at least one valid variable
+        let has_valid_var = VALID_SNAPSHOT_VARIABLES.iter().any(|v| format.contains(v));
+
+        if !has_valid_var {
+            return Err(ErrorInfo::validation(
+                format!(
+                    "snapshot format '{}' must contain at least one valid variable: {}",
+                    format,
+                    VALID_SNAPSHOT_VARIABLES.join(", ")
+                ),
+                Some("format"),
+            ));
+        }
+
+        Ok(())
+    }
 }

--- a/packages/workspace-tools/npm/darwin-arm64/package.json
+++ b/packages/workspace-tools/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-arm64",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/darwin-x64/package.json
+++ b/packages/workspace-tools/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-x64",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-gnu",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-musl",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-gnu",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-musl",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/win32-arm64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-arm64-msvc",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/win32-x64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-x64-msvc",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "Bindings for node from crate workspace-tools",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/types/index.d.cts",

--- a/packages/workspace-tools/src/binding.d.ts
+++ b/packages/workspace-tools/src/binding.d.ts
@@ -350,6 +350,63 @@ export interface BumpApplyParams {
 }
 
 /**
+ * Preview version bumps without applying changes.
+ *
+ * Returns comprehensive information about what versions would change based on
+ * pending changesets. This is a dry-run operation that does not modify any files.
+ *
+ * This function is the main entry point for Node.js applications to preview
+ * version bumps. It handles all the complexity of CLI invocation and response
+ * parsing internally.
+ *
+ * @param params - Preview parameters containing:
+ *   - `root`: Workspace root directory path (required)
+ *   - `configPath`: Optional custom config file path
+ *   - `packages`: Optional filter to specific packages
+ *   - `showDiff`: Whether to show detailed version diffs
+ *
+ * @returns `Promise<ApiResponse<BumpPreviewData>>` containing:
+ *   - On success: `{ success: true, data: BumpPreviewData }`
+ *   - On failure: `{ success: false, error: ErrorInfo }`
+ *
+ * @example Basic usage
+ * ```typescript
+ * const result = await bumpPreview({ root: '/path/to/project' });
+ * if (result.success) {
+ *   console.log(`Strategy: ${result.data.strategy}`);
+ *   console.log(`Packages to bump: ${result.data.packages.length}`);
+ *   for (const pkg of result.data.packages) {
+ *     console.log(`  ${pkg.name}: ${pkg.currentVersion} -> ${pkg.nextVersion}`);
+ *   }
+ * } else {
+ *   console.error(`Error: ${result.error.code} - ${result.error.message}`);
+ * }
+ * ```
+ *
+ * @example With package filter and diff
+ * ```typescript
+ * const result = await bumpPreview({
+ *   root: '/path/to/project',
+ *   packages: ['@scope/core', '@scope/utils'],
+ *   showDiff: true
+ * });
+ * ```
+ *
+ * @example Error handling
+ * ```typescript
+ * const result = await bumpPreview({ root: '/nonexistent' });
+ * if (!result.success) {
+ *   if (result.error.code === 'ENOENT') {
+ *     console.error('Path not found');
+ *   } else if (result.error.code === 'EVALIDATION') {
+ *     console.error('Invalid parameters');
+ *   }
+ * }
+ * ```
+ */
+export declare function bumpPreview(params: BumpPreviewParams): Promise<BumpPreviewApiResponse>
+
+/**
  * API response for the bump preview command.
  *
  * This structure wraps `BumpPreviewData` in the standard `ApiResponse`

--- a/packages/workspace-tools/src/binding.js
+++ b/packages/workspace-tools/src/binding.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm-eabi')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-ia32-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-arm64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@websublime/workspace-tools-darwin-universal')
       const bindingPackageVersion = require('@websublime/workspace-tools-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-musleabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-ppc64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-s390x-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.0.11' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.11 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -572,6 +572,7 @@ if (!nativeBinding) {
 }
 
 module.exports = nativeBinding
+module.exports.bumpPreview = nativeBinding.bumpPreview
 module.exports.changesetAdd = nativeBinding.changesetAdd
 module.exports.changesetCheck = nativeBinding.changesetCheck
 module.exports.changesetHistory = nativeBinding.changesetHistory

--- a/packages/workspace-tools/src/index.ts
+++ b/packages/workspace-tools/src/index.ts
@@ -17,8 +17,9 @@
  * - `changesetRemove()` - Remove a changeset from the workspace (Story 4.6)
  * - `changesetHistory()` - Query archived changeset history (Story 4.7)
  * - `changesetCheck()` - Check if a changeset exists for a branch (Story 4.8)
+ * - `bumpPreview()` - Preview version bumps without applying changes (Story 5.2)
  *
- * Bump types (Story 5.1 - types only, commands in Stories 5.2-5.4):
+ * Bump types (Story 5.1 - types only, commands bumpApply/bumpSnapshot in Stories 5.3-5.4):
  * - `BumpPreviewParams`, `BumpPreviewData`, `BumpPreviewApiResponse`
  * - `BumpApplyParams`, `BumpApplyData`, `BumpApplyApiResponse`
  * - `BumpSnapshotParams`, `BumpSnapshotData`, `BumpSnapshotApiResponse`
@@ -42,9 +43,9 @@
  */
 
 // Re-export all functions from bindings
-import { changesetAdd, changesetCheck, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status } from './binding'
+import { bumpPreview, changesetAdd, changesetCheck, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status } from './binding'
 
-export { changesetAdd, changesetCheck, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status }
+export { bumpPreview, changesetAdd, changesetCheck, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status }
 
 // Re-export all types from bindings
 export type {


### PR DESCRIPTION
- Add bump_preview async function exposed as bumpPreview to JavaScript
- Implement SharedBuffer for CLI output capture
- Add CLI response types for JSON parsing (CliBumpSnapshot, CliPackageBumpInfo, etc.)
- Add conversion functions from CLI to NAPI types
- Add validate_preview_params and convert_params_to_args functions
- Add prerelease_tag and snapshot_format validators for future stories
- Export bump_preview from commands/mod.rs and lib.rs
- Update index.ts to export bumpPreview function
- Regenerate bindings with napi-rs
- Add 50+ tests for bump preview functionality

Story 5.2 acceptance criteria met:
- Returns preview of changes (BumpPreviewData)
- No actual changes made (dry_run = true)
- showDiff option works correctly
- Returns strategy, packages, summary, and changesets