### PR TITLE
feat(WOR-TSK-193): implement bumpApply NAPI function

### DIFF
--- a/crates/node/src/commands/bump.rs
+++ b/crates/node/src/commands/bump.rs
@@ -126,12 +126,13 @@ use serde::Deserialize;
 
 use crate::error::ErrorInfo;
 use crate::types::bump::{
-    BumpPreviewApiResponse, BumpPreviewData, BumpPreviewParams, BumpSummaryInfo, PackageVersionInfo,
+    BumpApplyApiResponse, BumpApplyData, BumpApplyParams, BumpPreviewApiResponse, BumpPreviewData,
+    BumpPreviewParams, BumpSummaryInfo, PackageVersionInfo,
 };
 use crate::validation::validators;
 
 use sublime_cli_tools::cli::commands::BumpArgs;
-use sublime_cli_tools::commands::bump::execute_bump_preview;
+use sublime_cli_tools::commands::bump::{execute_bump_apply, execute_bump_preview};
 use sublime_cli_tools::output::{Output, OutputFormat};
 
 // ============================================================================
@@ -335,6 +336,50 @@ pub(crate) struct CliBumpSummary {
 }
 
 // ============================================================================
+// CLI Response Types for bump apply (execute result)
+// ============================================================================
+
+/// CLI JSON response wrapper for bump apply (execute) command.
+///
+/// This type mirrors the `JsonResponse<ExecuteResult>` structure from the CLI crate,
+/// used for deserializing the captured JSON output from `execute_bump_apply`.
+///
+/// Note: The CLI's `ExecuteResult` uses snake_case for field names (no `rename_all`
+/// attribute), so we must use snake_case here to match the JSON output.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliApplyJsonResponse {
+    /// Whether the operation succeeded.
+    pub(crate) success: bool,
+    /// The response data (present when success is true).
+    pub(crate) data: Option<CliExecuteResult>,
+    /// Error message (present when success is false).
+    pub(crate) error: Option<String>,
+}
+
+/// CLI execute result data structure.
+///
+/// Mirrors the `ExecuteResult` structure from the CLI's bump execute command.
+/// Note: The CLI uses snake_case for JSON serialization (no `rename_all` attribute).
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliExecuteResult {
+    /// Versioning strategy used (Independent or Unified).
+    pub(crate) strategy: String,
+    /// Number of packages that were updated.
+    pub(crate) packages_updated: usize,
+    /// Number of changesets that were archived.
+    pub(crate) changesets_archived: usize,
+    /// List of files that were modified (as PathBuf serialized strings).
+    pub(crate) files_modified: Vec<String>,
+    /// List of Git tags that were created.
+    pub(crate) tags_created: Vec<String>,
+    /// Git commit SHA (if commit was created).
+    pub(crate) commit_sha: Option<String>,
+    /// Full snapshot of the bump operation (not used in NAPI response, but required for parsing).
+    #[allow(dead_code)]
+    pub(crate) snapshot: CliBumpSnapshot,
+}
+
+// ============================================================================
 // Conversion Functions
 // ============================================================================
 
@@ -464,6 +509,84 @@ pub(crate) fn parse_preview_response(json_bytes: &[u8]) -> Result<BumpPreviewDat
 }
 
 // ============================================================================
+// Conversion Functions for bump apply
+// ============================================================================
+
+/// Converts CLI execute result to NAPI-compatible `BumpApplyData`.
+///
+/// This function performs a conversion from the CLI's internal types to the
+/// NAPI types exposed to JavaScript.
+///
+/// # Arguments
+///
+/// * `cli_data` - The parsed CLI execute result
+///
+/// # Returns
+///
+/// A `BumpApplyData` instance suitable for returning to JavaScript.
+#[allow(clippy::cast_possible_truncation)]
+// Justification: It's practically impossible to have more than 4 billion packages
+// or changesets in a workspace. The u32 limit is sufficient for any real-world scenario.
+pub(crate) fn convert_to_napi_apply(cli_data: CliExecuteResult) -> BumpApplyData {
+    BumpApplyData {
+        strategy: cli_data.strategy.to_lowercase(),
+        packages_updated: cli_data.packages_updated as u32,
+        changesets_archived: cli_data.changesets_archived as u32,
+        files_modified: cli_data.files_modified,
+        tags_created: cli_data.tags_created,
+        commit_sha: cli_data.commit_sha,
+    }
+}
+
+/// Parses the JSON response from the CLI apply command and converts it to NAPI types.
+///
+/// # Arguments
+///
+/// * `json_bytes` - The raw JSON bytes captured from CLI output
+///
+/// # Returns
+///
+/// * `Ok(BumpApplyData)` - Successfully parsed and converted apply data
+/// * `Err(ErrorInfo)` - Parsing failed or CLI returned an error
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The JSON is malformed or cannot be parsed
+/// - The CLI returned `success: false` with an error message
+/// - The CLI returned `success: true` but `data` is missing
+pub(crate) fn parse_apply_response(json_bytes: &[u8]) -> Result<BumpApplyData, ErrorInfo> {
+    // Convert bytes to string first for better error messages
+    let json_str = std::str::from_utf8(json_bytes)
+        .map_err(|e| ErrorInfo::execution(format!("Invalid UTF-8 in CLI response: {e}")))?;
+
+    // Handle empty response
+    if json_str.trim().is_empty() {
+        return Err(ErrorInfo::execution("CLI returned empty response"));
+    }
+
+    // Parse the JSON response
+    let response: CliApplyJsonResponse = serde_json::from_str(json_str).map_err(|e| {
+        ErrorInfo::execution(format!(
+            "Failed to parse CLI JSON response: {e} (length={})",
+            json_str.len()
+        ))
+    })?;
+
+    // Check for CLI-level errors
+    if !response.success {
+        let error_message = response.error.unwrap_or_else(|| "Unknown CLI error".to_string());
+        return Err(ErrorInfo::execution(error_message));
+    }
+
+    // Extract and convert data
+    let cli_data =
+        response.data.ok_or_else(|| ErrorInfo::execution("CLI returned success but no data"))?;
+
+    Ok(convert_to_napi_apply(cli_data))
+}
+
+// ============================================================================
 // Parameter Validation
 // ============================================================================
 
@@ -482,6 +605,30 @@ pub(crate) fn parse_preview_response(json_bytes: &[u8]) -> Result<BumpPreviewDat
 pub(crate) fn validate_preview_params(params: &BumpPreviewParams) -> Result<PathBuf, ErrorInfo> {
     // Validate root path exists and is a directory
     validators::root(&params.root)?;
+
+    Ok(PathBuf::from(&params.root))
+}
+
+/// Validates bump apply command parameters.
+///
+/// Ensures the root path is valid and validates the prerelease tag if provided.
+///
+/// # Arguments
+///
+/// * `params` - The apply parameters to validate
+///
+/// # Returns
+///
+/// * `Ok(PathBuf)` - The validated root path
+/// * `Err(ErrorInfo)` - Validation failed
+pub(crate) fn validate_apply_params(params: &BumpApplyParams) -> Result<PathBuf, ErrorInfo> {
+    // Validate root path exists and is a directory
+    validators::root(&params.root)?;
+
+    // Validate prerelease tag if provided
+    if let Some(ref tag) = params.prerelease {
+        validators::prerelease_tag(tag)?;
+    }
 
     Ok(PathBuf::from(&params.root))
 }
@@ -525,6 +672,51 @@ pub(crate) fn convert_params_to_args(params: &BumpPreviewParams) -> BumpArgs {
 
         // Show diff from params
         show_diff: params.show_diff.unwrap_or(false),
+    }
+}
+
+/// Converts `BumpApplyParams` to CLI `BumpArgs`.
+///
+/// This function sets the appropriate flags for execute mode (execute = true)
+/// and maps all NAPI parameters to CLI arguments including git operations,
+/// prerelease support, and changelog/archive control.
+///
+/// # Arguments
+///
+/// * `params` - The NAPI apply parameters
+///
+/// # Returns
+///
+/// A `BumpArgs` struct configured for execute mode.
+pub(crate) fn convert_apply_params_to_args(params: &BumpApplyParams) -> BumpArgs {
+    BumpArgs {
+        // Execute mode: execute = true, no dry run
+        dry_run: false,
+        execute: true,
+        snapshot: false,
+        snapshot_format: None,
+
+        // Prerelease support
+        prerelease: params.prerelease.clone(),
+
+        // Package filter from params
+        packages: params.packages.clone(),
+
+        // Git operations from params
+        git_tag: params.git_tag.unwrap_or(false),
+        git_push: params.git_push.unwrap_or(false),
+        git_commit: params.git_commit.unwrap_or(false),
+
+        // Changelog and archive control
+        no_changelog: params.no_changelog.unwrap_or(false),
+        no_archive: params.no_archive.unwrap_or(false),
+        always_archive: params.always_archive.unwrap_or(false),
+
+        // Skip confirmations (API is non-interactive by default)
+        force: params.force.unwrap_or(true),
+
+        // No diff display in execute mode
+        show_diff: false,
     }
 }
 
@@ -644,19 +836,162 @@ pub async fn bump_preview(params: BumpPreviewParams) -> BumpPreviewApiResponse {
     }
 }
 
-// TODO: will be implemented on story 5.3 - bumpApply
-//
-// #[napi(js_name = "bumpApply")]
-// pub async fn bump_apply(params: BumpApplyParams) -> BumpApplyApiResponse {
-//     // Implementation will include:
-//     // 1. Validate parameters including prerelease tag if provided
-//     // 2. Create BumpArgs with execute = true
-//     // 3. Support git operations (commit, tag, push)
-//     // 4. Support prerelease parameter for alpha/beta/rc versions
-//     // 5. Support changelog/archive control
-//     // 6. Execute CLI command and parse response
-//     todo!()
-// }
+/// Apply version bumps to packages.
+///
+/// Applies version changes based on pending changesets. This is the main
+/// release command that modifies package.json files, generates changelogs,
+/// archives changesets, and optionally creates Git commits and tags.
+///
+/// This function is the main entry point for Node.js applications to apply
+/// version bumps. It handles all the complexity of CLI invocation and response
+/// parsing internally.
+///
+/// @param params - Apply parameters containing:
+///   - `root`: Workspace root directory path (required)
+///   - `configPath`: Optional custom config file path
+///   - `packages`: Optional filter to specific packages
+///   - `gitCommit`: Whether to create a Git commit with version changes
+///   - `gitTag`: Whether to create Git tags for releases
+///   - `gitPush`: Whether to push Git tags to remote
+///   - `prerelease`: Prerelease tag (alpha, beta, rc, or custom)
+///   - `noChangelog`: Whether to skip changelog generation
+///   - `noArchive`: Whether to keep changesets active after bump
+///   - `alwaysArchive`: Whether to force archiving for prereleases
+///   - `force`: Whether to skip confirmation prompts (default: true)
+///
+/// @returns `Promise<ApiResponse<BumpApplyData>>` containing:
+///   - On success: `{ success: true, data: BumpApplyData }`
+///   - On failure: `{ success: false, error: ErrorInfo }`
+///
+/// @example Basic usage - apply bumps without Git operations
+/// ```typescript
+/// const result = await bumpApply({ root: '/path/to/project' });
+/// if (result.success) {
+///   console.log(`Updated ${result.data.packagesUpdated} packages`);
+///   console.log(`Archived ${result.data.changesetsArchived} changesets`);
+///   console.log(`Modified files: ${result.data.filesModified.join(', ')}`);
+/// } else {
+///   console.error(`Error: ${result.error.code} - ${result.error.message}`);
+/// }
+/// ```
+///
+/// @example With Git operations
+/// ```typescript
+/// const result = await bumpApply({
+///   root: '/path/to/project',
+///   gitCommit: true,
+///   gitTag: true,
+///   gitPush: true
+/// });
+/// if (result.success) {
+///   console.log(`Commit SHA: ${result.data.commitSha}`);
+///   console.log(`Tags created: ${result.data.tagsCreated.join(', ')}`);
+/// }
+/// ```
+///
+/// @example Prerelease version (beta)
+/// ```typescript
+/// const result = await bumpApply({
+///   root: '/path/to/project',
+///   prerelease: 'beta',
+///   gitCommit: true,
+///   gitTag: true
+/// });
+/// // Creates versions like 1.3.0-beta.0
+/// ```
+///
+/// @example Skip changelog and archive
+/// ```typescript
+/// const result = await bumpApply({
+///   root: '/path/to/project',
+///   noChangelog: true,
+///   noArchive: true
+/// });
+/// // Updates versions but keeps changesets and skips changelog
+/// ```
+///
+/// @example Force archive for prerelease
+/// ```typescript
+/// const result = await bumpApply({
+///   root: '/path/to/project',
+///   prerelease: 'rc',
+///   alwaysArchive: true,  // Archive changesets even for prerelease
+///   gitCommit: true,
+///   gitTag: true
+/// });
+/// ```
+///
+/// @example Error handling
+/// ```typescript
+/// const result = await bumpApply({ root: '/nonexistent' });
+/// if (!result.success) {
+///   if (result.error.code === 'ENOENT') {
+///     console.error('Path not found');
+///   } else if (result.error.code === 'EVALIDATION') {
+///     console.error('Invalid parameters:', result.error.message);
+///   } else if (result.error.code === 'EGIT') {
+///     console.error('Git operation failed:', result.error.message);
+///   }
+/// }
+/// ```
+#[napi(js_name = "bumpApply")]
+pub async fn bump_apply(params: BumpApplyParams) -> BumpApplyApiResponse {
+    // 1. Validate parameters (synchronous validation before spawning)
+    let root_path = match validate_apply_params(&params) {
+        Ok(path) => path,
+        Err(error) => return BumpApplyApiResponse::failure(error),
+    };
+
+    // 2. Prepare config path
+    let config_path: Option<PathBuf> = params.config_path.as_ref().map(PathBuf::from);
+
+    // 3. Convert params to CLI args
+    let args = convert_apply_params_to_args(&params);
+
+    // 4. Execute CLI command in a blocking task
+    // The CLI's execute_bump_apply uses types that are not Send/Sync (RefCell, git2::Repository),
+    // so we must run it on a blocking thread via spawn_blocking.
+    let result = tokio::task::spawn_blocking(move || {
+        // Create a new tokio runtime for the blocking context
+        // This is necessary because execute_bump_apply is async but we're in a blocking context
+        let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                return Err(ErrorInfo::execution(format!("Failed to create runtime: {e}")));
+            }
+        };
+
+        rt.block_on(async {
+            // Create shared buffer for output capture
+            let buffer = SharedBuffer::new();
+
+            // Create Output with JSON format
+            let output = Output::new(OutputFormat::Json, buffer.clone(), true);
+
+            // Execute the CLI command
+            let config_path_ref: Option<&Path> = config_path.as_deref();
+            if let Err(cli_error) =
+                execute_bump_apply(&args, &output, &root_path, config_path_ref).await
+            {
+                return Err(ErrorInfo::from(cli_error));
+            }
+
+            // Extract and parse JSON
+            let json_bytes = buffer.take_bytes();
+            parse_apply_response(&json_bytes)
+        })
+    })
+    .await;
+
+    // 5. Handle spawn_blocking result
+    match result {
+        Ok(Ok(data)) => BumpApplyApiResponse::success(data),
+        Ok(Err(error)) => BumpApplyApiResponse::failure(error),
+        Err(join_error) => BumpApplyApiResponse::failure(ErrorInfo::execution(format!(
+            "Task execution failed: {join_error}"
+        ))),
+    }
+}
 
 // TODO: will be implemented on story 5.4 - bumpSnapshot
 //

--- a/crates/node/src/commands/mod.rs
+++ b/crates/node/src/commands/mod.rs
@@ -94,7 +94,8 @@ pub(crate) mod bump;
 // Re-export bump functions for lib.rs
 // Story 5.2: bumpPreview
 pub use bump::bump_preview;
-// TODO: will be implemented on story 5.3 (bumpApply)
+// Story 5.3: bumpApply
+pub use bump::bump_apply;
 // TODO: will be implemented on story 5.4 (bumpSnapshot)
 
 // TODO: will be implemented on story 8.2-8.4 (upgrade commands)

--- a/crates/node/src/commands/tests.rs
+++ b/crates/node/src/commands/tests.rs
@@ -4830,3 +4830,674 @@ mod bump_validator_tests {
         }
     }
 }
+
+// ============================================================================
+// Bump Apply Tests (Story 5.3)
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod bump_apply_tests {
+    use std::io::Write;
+
+    use tempfile::TempDir;
+
+    use crate::commands::bump::{
+        CliBumpSnapshot, CliBumpSummary, CliExecuteResult, SharedBuffer,
+        convert_apply_params_to_args, convert_to_napi_apply, parse_apply_response,
+        validate_apply_params,
+    };
+    use crate::types::bump::BumpApplyParams;
+
+    // -------------------------------------------------------------------------
+    // SharedBuffer Tests (reused pattern, but validated for apply context)
+    // -------------------------------------------------------------------------
+
+    mod shared_buffer_tests {
+        use super::*;
+
+        #[test]
+        fn test_shared_buffer_new() {
+            let buffer = SharedBuffer::new();
+            assert!(buffer.take_bytes().is_empty());
+        }
+
+        #[test]
+        fn test_shared_buffer_write() {
+            let mut buffer = SharedBuffer::new();
+            let bytes_written = buffer.write(b"apply result").unwrap();
+            assert_eq!(bytes_written, 12);
+            assert_eq!(buffer.take_bytes(), b"apply result");
+        }
+
+        #[test]
+        fn test_shared_buffer_multiple_writes() {
+            let mut buffer = SharedBuffer::new();
+            buffer.write_all(b"packages ").unwrap();
+            buffer.write_all(b"updated").unwrap();
+            assert_eq!(buffer.take_bytes(), b"packages updated");
+        }
+
+        #[test]
+        fn test_shared_buffer_clone_shares_data() {
+            let mut buffer = SharedBuffer::new();
+            let buffer_clone = buffer.clone();
+            buffer.write_all(b"shared apply data").unwrap();
+
+            // Both buffers should see the same data
+            assert_eq!(buffer.take_bytes(), b"shared apply data");
+            assert_eq!(buffer_clone.take_bytes(), b"shared apply data");
+        }
+
+        #[test]
+        fn test_shared_buffer_flush() {
+            let mut buffer = SharedBuffer::new();
+            assert!(buffer.flush().is_ok());
+        }
+
+        #[test]
+        fn test_shared_buffer_take_bytes_preserves_data() {
+            let mut buffer = SharedBuffer::new();
+            buffer.write_all(b"apply test data").unwrap();
+
+            // Multiple takes should return same data
+            let first_take = buffer.take_bytes();
+            let second_take = buffer.take_bytes();
+            assert_eq!(first_take, second_take);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Parse Response Tests
+    // -------------------------------------------------------------------------
+
+    mod parse_response_tests {
+        use super::*;
+
+        #[test]
+        fn test_parse_apply_response_success() {
+            // Note: CLI uses snake_case (no rename_all attribute)
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "strategy": "Independent",
+                    "packages_updated": 2,
+                    "changesets_archived": 1,
+                    "files_modified": [
+                        "packages/core/package.json",
+                        "packages/core/CHANGELOG.md",
+                        "packages/utils/package.json"
+                    ],
+                    "tags_created": ["@scope/core@1.1.0", "@scope/utils@2.0.0"],
+                    "commit_sha": "abc123def456789",
+                    "snapshot": {
+                        "strategy": "Independent",
+                        "packages": [],
+                        "changesets": [],
+                        "summary": {
+                            "totalPackages": 0,
+                            "packagesToBump": 0,
+                            "packagesUnchanged": 0,
+                            "totalChangesets": 0,
+                            "hasCircularDependencies": false
+                        }
+                    }
+                }
+            }"#;
+
+            let result = parse_apply_response(json.as_bytes());
+            assert!(result.is_ok());
+            let data = result.unwrap();
+            assert_eq!(data.strategy, "independent");
+            assert_eq!(data.packages_updated, 2);
+            assert_eq!(data.changesets_archived, 1);
+            assert_eq!(data.files_modified.len(), 3);
+            assert!(data.files_modified.contains(&"packages/core/package.json".to_string()));
+            assert!(data.files_modified.contains(&"packages/core/CHANGELOG.md".to_string()));
+            assert_eq!(data.tags_created.len(), 2);
+            assert!(data.tags_created.contains(&"@scope/core@1.1.0".to_string()));
+            assert_eq!(data.commit_sha, Some("abc123def456789".to_string()));
+        }
+
+        #[test]
+        fn test_parse_apply_response_no_git_operations() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "strategy": "Unified",
+                    "packages_updated": 3,
+                    "changesets_archived": 2,
+                    "files_modified": ["packages/core/package.json"],
+                    "tags_created": [],
+                    "commit_sha": null,
+                    "snapshot": {
+                        "strategy": "Unified",
+                        "packages": [],
+                        "changesets": [],
+                        "summary": {
+                            "totalPackages": 0,
+                            "packagesToBump": 0,
+                            "packagesUnchanged": 0,
+                            "totalChangesets": 0,
+                            "hasCircularDependencies": false
+                        }
+                    }
+                }
+            }"#;
+
+            let result = parse_apply_response(json.as_bytes());
+            assert!(result.is_ok());
+            let data = result.unwrap();
+            assert_eq!(data.strategy, "unified");
+            assert_eq!(data.packages_updated, 3);
+            assert_eq!(data.changesets_archived, 2);
+            assert!(data.tags_created.is_empty());
+            assert!(data.commit_sha.is_none());
+        }
+
+        #[test]
+        fn test_parse_apply_response_nothing_to_bump() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "strategy": "Independent",
+                    "packages_updated": 0,
+                    "changesets_archived": 0,
+                    "files_modified": [],
+                    "tags_created": [],
+                    "commit_sha": null,
+                    "snapshot": {
+                        "strategy": "Independent",
+                        "packages": [],
+                        "changesets": [],
+                        "summary": {
+                            "totalPackages": 0,
+                            "packagesToBump": 0,
+                            "packagesUnchanged": 0,
+                            "totalChangesets": 0,
+                            "hasCircularDependencies": false
+                        }
+                    }
+                }
+            }"#;
+
+            let result = parse_apply_response(json.as_bytes());
+            assert!(result.is_ok());
+            let data = result.unwrap();
+            assert_eq!(data.packages_updated, 0);
+            assert_eq!(data.changesets_archived, 0);
+            assert!(data.files_modified.is_empty());
+        }
+
+        #[test]
+        fn test_parse_apply_response_cli_error() {
+            let json = r#"{
+                "success": false,
+                "error": "Git repository has uncommitted changes"
+            }"#;
+
+            let result = parse_apply_response(json.as_bytes());
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EEXEC");
+            assert!(error.message.contains("uncommitted changes"));
+        }
+
+        #[test]
+        fn test_parse_apply_response_empty() {
+            let result = parse_apply_response(b"");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("empty response"));
+        }
+
+        #[test]
+        fn test_parse_apply_response_whitespace_only() {
+            let result = parse_apply_response(b"   \n  \t  ");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("empty response"));
+        }
+
+        #[test]
+        fn test_parse_apply_response_invalid_json() {
+            let result = parse_apply_response(b"not valid json");
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Failed to parse"));
+        }
+
+        #[test]
+        fn test_parse_apply_response_invalid_utf8() {
+            let invalid_utf8 = vec![0xFF, 0xFE, 0x00, 0x01];
+            let result = parse_apply_response(&invalid_utf8);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Invalid UTF-8"));
+        }
+
+        #[test]
+        fn test_parse_apply_response_success_no_data() {
+            let json = r#"{"success": true}"#;
+            let result = parse_apply_response(json.as_bytes());
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("no data"));
+        }
+
+        #[test]
+        fn test_parse_apply_response_cli_error_no_message() {
+            let json = r#"{"success": false}"#;
+            let result = parse_apply_response(json.as_bytes());
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Unknown CLI error"));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Conversion Tests
+    // -------------------------------------------------------------------------
+
+    mod conversion_tests {
+        use super::*;
+
+        #[test]
+        fn test_convert_to_napi_apply_full() {
+            let cli_data = CliExecuteResult {
+                strategy: "Independent".to_string(),
+                packages_updated: 3,
+                changesets_archived: 2,
+                files_modified: vec![
+                    "packages/core/package.json".to_string(),
+                    "packages/core/CHANGELOG.md".to_string(),
+                    "packages/utils/package.json".to_string(),
+                ],
+                tags_created: vec![
+                    "@scope/core@1.1.0".to_string(),
+                    "@scope/utils@2.0.0".to_string(),
+                ],
+                commit_sha: Some("abc123def456789".to_string()),
+                snapshot: CliBumpSnapshot {
+                    strategy: "Independent".to_string(),
+                    packages: vec![],
+                    changesets: vec![],
+                    summary: CliBumpSummary {
+                        total_packages: 0,
+                        packages_to_bump: 0,
+                        packages_unchanged: 0,
+                        total_changesets: 0,
+                        has_circular_dependencies: false,
+                    },
+                },
+            };
+
+            let result = convert_to_napi_apply(cli_data);
+
+            assert_eq!(result.strategy, "independent");
+            assert_eq!(result.packages_updated, 3);
+            assert_eq!(result.changesets_archived, 2);
+            assert_eq!(result.files_modified.len(), 3);
+            assert_eq!(result.tags_created.len(), 2);
+            assert_eq!(result.commit_sha, Some("abc123def456789".to_string()));
+        }
+
+        #[test]
+        fn test_convert_to_napi_apply_no_git() {
+            let cli_data = CliExecuteResult {
+                strategy: "Unified".to_string(),
+                packages_updated: 1,
+                changesets_archived: 1,
+                files_modified: vec!["packages/pkg/package.json".to_string()],
+                tags_created: vec![],
+                commit_sha: None,
+                snapshot: CliBumpSnapshot {
+                    strategy: "Unified".to_string(),
+                    packages: vec![],
+                    changesets: vec![],
+                    summary: CliBumpSummary {
+                        total_packages: 0,
+                        packages_to_bump: 0,
+                        packages_unchanged: 0,
+                        total_changesets: 0,
+                        has_circular_dependencies: false,
+                    },
+                },
+            };
+
+            let result = convert_to_napi_apply(cli_data);
+
+            assert_eq!(result.strategy, "unified");
+            assert_eq!(result.packages_updated, 1);
+            assert!(result.tags_created.is_empty());
+            assert!(result.commit_sha.is_none());
+        }
+
+        #[test]
+        fn test_convert_to_napi_apply_empty() {
+            let cli_data = CliExecuteResult {
+                strategy: "Independent".to_string(),
+                packages_updated: 0,
+                changesets_archived: 0,
+                files_modified: vec![],
+                tags_created: vec![],
+                commit_sha: None,
+                snapshot: CliBumpSnapshot {
+                    strategy: "Independent".to_string(),
+                    packages: vec![],
+                    changesets: vec![],
+                    summary: CliBumpSummary {
+                        total_packages: 0,
+                        packages_to_bump: 0,
+                        packages_unchanged: 0,
+                        total_changesets: 0,
+                        has_circular_dependencies: false,
+                    },
+                },
+            };
+
+            let result = convert_to_napi_apply(cli_data);
+
+            assert_eq!(result.packages_updated, 0);
+            assert_eq!(result.changesets_archived, 0);
+            assert!(result.files_modified.is_empty());
+            assert!(result.tags_created.is_empty());
+        }
+
+        #[test]
+        fn test_convert_apply_params_to_args_defaults() {
+            let params = BumpApplyParams::new("/path/to/project");
+            let args = convert_apply_params_to_args(&params);
+
+            // Execute mode settings
+            assert!(!args.dry_run);
+            assert!(args.execute);
+            assert!(!args.snapshot);
+
+            // Default git operations (all false)
+            assert!(!args.git_commit);
+            assert!(!args.git_tag);
+            assert!(!args.git_push);
+
+            // No prerelease by default
+            assert!(args.prerelease.is_none());
+
+            // Default changelog/archive settings
+            assert!(!args.no_changelog);
+            assert!(!args.no_archive);
+            assert!(!args.always_archive);
+
+            // Force is true for API (non-interactive)
+            assert!(args.force);
+
+            // No diff in execute mode
+            assert!(!args.show_diff);
+
+            // No package filter by default
+            assert!(args.packages.is_none());
+        }
+
+        #[test]
+        fn test_convert_apply_params_to_args_with_git_operations() {
+            let params = BumpApplyParams::new("/path/to/project")
+                .with_git_commit(true)
+                .with_git_tag(true)
+                .with_git_push(true);
+            let args = convert_apply_params_to_args(&params);
+
+            assert!(args.git_commit);
+            assert!(args.git_tag);
+            assert!(args.git_push);
+        }
+
+        #[test]
+        fn test_convert_apply_params_to_args_with_prerelease() {
+            let params = BumpApplyParams::new("/path/to/project").with_prerelease("beta");
+            let args = convert_apply_params_to_args(&params);
+
+            assert_eq!(args.prerelease, Some("beta".to_string()));
+        }
+
+        #[test]
+        fn test_convert_apply_params_to_args_with_changelog_control() {
+            let params = BumpApplyParams::new("/path/to/project").with_no_changelog(true);
+            let args = convert_apply_params_to_args(&params);
+
+            assert!(args.no_changelog);
+        }
+
+        #[test]
+        fn test_convert_apply_params_to_args_with_archive_control() {
+            let params = BumpApplyParams::new("/path/to/project")
+                .with_no_archive(true)
+                .with_always_archive(false);
+            let args = convert_apply_params_to_args(&params);
+
+            assert!(args.no_archive);
+            assert!(!args.always_archive);
+        }
+
+        #[test]
+        fn test_convert_apply_params_to_args_always_archive_for_prerelease() {
+            let params = BumpApplyParams::new("/path/to/project")
+                .with_prerelease("rc")
+                .with_always_archive(true);
+            let args = convert_apply_params_to_args(&params);
+
+            assert_eq!(args.prerelease, Some("rc".to_string()));
+            assert!(args.always_archive);
+        }
+
+        #[test]
+        fn test_convert_apply_params_to_args_with_packages() {
+            let params = BumpApplyParams::new("/path/to/project")
+                .with_packages(vec!["@scope/core".to_string(), "@scope/utils".to_string()]);
+            let args = convert_apply_params_to_args(&params);
+
+            assert_eq!(
+                args.packages,
+                Some(vec!["@scope/core".to_string(), "@scope/utils".to_string()])
+            );
+        }
+
+        #[test]
+        fn test_convert_apply_params_to_args_force_false() {
+            let params = BumpApplyParams::new("/path/to/project").with_force(false);
+            let args = convert_apply_params_to_args(&params);
+
+            assert!(!args.force);
+        }
+
+        #[test]
+        fn test_convert_apply_params_to_args_full_release() {
+            // Simulates a full release with git operations and archiving
+            let params = BumpApplyParams::new("/path/to/project")
+                .with_git_commit(true)
+                .with_git_tag(true)
+                .with_git_push(true)
+                .with_force(true);
+            let args = convert_apply_params_to_args(&params);
+
+            assert!(!args.dry_run);
+            assert!(args.execute);
+            assert!(args.git_commit);
+            assert!(args.git_tag);
+            assert!(args.git_push);
+            assert!(!args.no_changelog);
+            assert!(!args.no_archive);
+            assert!(args.force);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation Tests
+    // -------------------------------------------------------------------------
+
+    mod validation_tests {
+        use super::*;
+
+        #[test]
+        fn test_validate_apply_params_valid_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str);
+            let result = validate_apply_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_apply_params_nonexistent_path() {
+            let params = BumpApplyParams::new("/nonexistent/path/to/project");
+            let result = validate_apply_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "ENOENT");
+        }
+
+        #[test]
+        fn test_validate_apply_params_empty_root() {
+            let params = BumpApplyParams::new("");
+            let result = validate_apply_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+        }
+
+        #[test]
+        fn test_validate_apply_params_file_not_directory() {
+            let temp_dir = TempDir::new().unwrap();
+            let file_path = temp_dir.path().join("test.txt");
+            std::fs::write(&file_path, "test content").unwrap();
+
+            let params = BumpApplyParams::new(file_path.to_str().unwrap());
+            let result = validate_apply_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+        }
+
+        #[test]
+        fn test_validate_apply_params_valid_prerelease_alpha() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str).with_prerelease("alpha");
+            let result = validate_apply_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_apply_params_valid_prerelease_beta() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str).with_prerelease("beta");
+            let result = validate_apply_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_apply_params_valid_prerelease_rc() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str).with_prerelease("rc");
+            let result = validate_apply_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_apply_params_valid_prerelease_custom() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str).with_prerelease("next-1");
+            let result = validate_apply_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_apply_params_invalid_prerelease_period() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str).with_prerelease("alpha.1");
+            let result = validate_apply_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("invalid characters"));
+        }
+
+        #[test]
+        fn test_validate_apply_params_invalid_prerelease_empty() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str).with_prerelease("");
+            let result = validate_apply_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert!(error.message.contains("cannot be empty"));
+        }
+
+        #[test]
+        fn test_validate_apply_params_invalid_prerelease_underscore() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str).with_prerelease("beta_1");
+            let result = validate_apply_params(&params);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn test_validate_apply_params_with_git_options() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str)
+                .with_git_commit(true)
+                .with_git_tag(true)
+                .with_git_push(true);
+            let result = validate_apply_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_apply_params_with_packages() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params =
+                BumpApplyParams::new(path_str).with_packages(vec!["@scope/core".to_string()]);
+            let result = validate_apply_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_apply_params_with_config_path() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str).with_config_path("/path/to/config.json");
+            let result = validate_apply_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_apply_params_returns_correct_path() {
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str);
+            let result = validate_apply_params(&params);
+            assert!(result.is_ok());
+            let path = result.unwrap();
+            assert_eq!(path.to_str().unwrap(), path_str);
+        }
+
+        #[test]
+        fn test_validate_apply_params_full_prerelease_workflow() {
+            // Beta prerelease with git and archiving
+            let temp_dir = TempDir::new().unwrap();
+            let path_str = temp_dir.path().to_str().unwrap();
+            let params = BumpApplyParams::new(path_str)
+                .with_prerelease("beta")
+                .with_git_commit(true)
+                .with_git_tag(true)
+                .with_always_archive(true);
+            let result = validate_apply_params(&params);
+            assert!(result.is_ok());
+        }
+    }
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -155,7 +155,8 @@ pub use commands::changeset_check;
 // Bump commands (Story 5.2-5.4)
 // Story 5.2: bumpPreview
 pub use commands::bump_preview;
-// TODO: will be implemented on story 5.3 (bumpApply)
+// Story 5.3: bumpApply
+pub use commands::bump_apply;
 // TODO: will be implemented on story 5.4 (bumpSnapshot)
 
 // TODO: will be implemented on story 6.3 (execute command)

--- a/packages/workspace-tools/npm/darwin-arm64/package.json
+++ b/packages/workspace-tools/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-arm64",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/darwin-x64/package.json
+++ b/packages/workspace-tools/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-x64",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-gnu",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-musl",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-gnu",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-musl",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/win32-arm64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-arm64-msvc",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/win32-x64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-x64-msvc",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Bindings for node from crate workspace-tools",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/types/index.d.cts",

--- a/packages/workspace-tools/src/binding.d.ts
+++ b/packages/workspace-tools/src/binding.d.ts
@@ -59,6 +59,108 @@ export interface BranchInfo {
 }
 
 /**
+ * Apply version bumps to packages.
+ *
+ * Applies version changes based on pending changesets. This is the main
+ * release command that modifies package.json files, generates changelogs,
+ * archives changesets, and optionally creates Git commits and tags.
+ *
+ * This function is the main entry point for Node.js applications to apply
+ * version bumps. It handles all the complexity of CLI invocation and response
+ * parsing internally.
+ *
+ * @param params - Apply parameters containing:
+ *   - `root`: Workspace root directory path (required)
+ *   - `configPath`: Optional custom config file path
+ *   - `packages`: Optional filter to specific packages
+ *   - `gitCommit`: Whether to create a Git commit with version changes
+ *   - `gitTag`: Whether to create Git tags for releases
+ *   - `gitPush`: Whether to push Git tags to remote
+ *   - `prerelease`: Prerelease tag (alpha, beta, rc, or custom)
+ *   - `noChangelog`: Whether to skip changelog generation
+ *   - `noArchive`: Whether to keep changesets active after bump
+ *   - `alwaysArchive`: Whether to force archiving for prereleases
+ *   - `force`: Whether to skip confirmation prompts (default: true)
+ *
+ * @returns `Promise<ApiResponse<BumpApplyData>>` containing:
+ *   - On success: `{ success: true, data: BumpApplyData }`
+ *   - On failure: `{ success: false, error: ErrorInfo }`
+ *
+ * @example Basic usage - apply bumps without Git operations
+ * ```typescript
+ * const result = await bumpApply({ root: '/path/to/project' });
+ * if (result.success) {
+ *   console.log(`Updated ${result.data.packagesUpdated} packages`);
+ *   console.log(`Archived ${result.data.changesetsArchived} changesets`);
+ *   console.log(`Modified files: ${result.data.filesModified.join(', ')}`);
+ * } else {
+ *   console.error(`Error: ${result.error.code} - ${result.error.message}`);
+ * }
+ * ```
+ *
+ * @example With Git operations
+ * ```typescript
+ * const result = await bumpApply({
+ *   root: '/path/to/project',
+ *   gitCommit: true,
+ *   gitTag: true,
+ *   gitPush: true
+ * });
+ * if (result.success) {
+ *   console.log(`Commit SHA: ${result.data.commitSha}`);
+ *   console.log(`Tags created: ${result.data.tagsCreated.join(', ')}`);
+ * }
+ * ```
+ *
+ * @example Prerelease version (beta)
+ * ```typescript
+ * const result = await bumpApply({
+ *   root: '/path/to/project',
+ *   prerelease: 'beta',
+ *   gitCommit: true,
+ *   gitTag: true
+ * });
+ * // Creates versions like 1.3.0-beta.0
+ * ```
+ *
+ * @example Skip changelog and archive
+ * ```typescript
+ * const result = await bumpApply({
+ *   root: '/path/to/project',
+ *   noChangelog: true,
+ *   noArchive: true
+ * });
+ * // Updates versions but keeps changesets and skips changelog
+ * ```
+ *
+ * @example Force archive for prerelease
+ * ```typescript
+ * const result = await bumpApply({
+ *   root: '/path/to/project',
+ *   prerelease: 'rc',
+ *   alwaysArchive: true,  // Archive changesets even for prerelease
+ *   gitCommit: true,
+ *   gitTag: true
+ * });
+ * ```
+ *
+ * @example Error handling
+ * ```typescript
+ * const result = await bumpApply({ root: '/nonexistent' });
+ * if (!result.success) {
+ *   if (result.error.code === 'ENOENT') {
+ *     console.error('Path not found');
+ *   } else if (result.error.code === 'EVALIDATION') {
+ *     console.error('Invalid parameters:', result.error.message);
+ *   } else if (result.error.code === 'EGIT') {
+ *     console.error('Git operation failed:', result.error.message);
+ *   }
+ * }
+ * ```
+ */
+export declare function bumpApply(params: BumpApplyParams): Promise<BumpApplyApiResponse>
+
+/**
  * API response for the bump apply command.
  *
  * This structure wraps `BumpApplyData` in the standard `ApiResponse`

--- a/packages/workspace-tools/src/binding.js
+++ b/packages/workspace-tools/src/binding.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm-eabi')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-ia32-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-arm64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@websublime/workspace-tools-darwin-universal')
       const bindingPackageVersion = require('@websublime/workspace-tools-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-musleabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-ppc64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-s390x-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.0.12' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.12 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.13' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.13 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -572,6 +572,7 @@ if (!nativeBinding) {
 }
 
 module.exports = nativeBinding
+module.exports.bumpApply = nativeBinding.bumpApply
 module.exports.bumpPreview = nativeBinding.bumpPreview
 module.exports.changesetAdd = nativeBinding.changesetAdd
 module.exports.changesetCheck = nativeBinding.changesetCheck

--- a/packages/workspace-tools/src/index.ts
+++ b/packages/workspace-tools/src/index.ts
@@ -18,8 +18,9 @@
  * - `changesetHistory()` - Query archived changeset history (Story 4.7)
  * - `changesetCheck()` - Check if a changeset exists for a branch (Story 4.8)
  * - `bumpPreview()` - Preview version bumps without applying changes (Story 5.2)
+ * - `bumpApply()` - Apply version bumps with Git integration and prerelease support (Story 5.3)
  *
- * Bump types (Story 5.1 - types only, commands bumpApply/bumpSnapshot in Stories 5.3-5.4):
+ * Bump types (Story 5.1 - types only, command bumpSnapshot in Story 5.4):
  * - `BumpPreviewParams`, `BumpPreviewData`, `BumpPreviewApiResponse`
  * - `BumpApplyParams`, `BumpApplyData`, `BumpApplyApiResponse`
  * - `BumpSnapshotParams`, `BumpSnapshotData`, `BumpSnapshotApiResponse`
@@ -43,9 +44,9 @@
  */
 
 // Re-export all functions from bindings
-import { bumpPreview, changesetAdd, changesetCheck, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status } from './binding'
+import { bumpApply, bumpPreview, changesetAdd, changesetCheck, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status } from './binding'
 
-export { bumpPreview, changesetAdd, changesetCheck, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status }
+export { bumpApply, bumpPreview, changesetAdd, changesetCheck, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status }
 
 // Re-export all types from bindings
 export type {


### PR DESCRIPTION
- Add bumpApply function with full prerelease and git integration support
- Support git operations: gitCommit, gitTag, gitPush
- Support prerelease versions: alpha, beta, rc, or custom tags
- Support changelog/archive control: noChangelog, noArchive, alwaysArchive
- Add CLI response types for parsing execute result JSON
- Add validate_apply_params with prerelease tag validation
- Add convert_apply_params_to_args for CLI argument mapping
- Add parse_apply_response for JSON parsing and conversion
- Add convert_to_napi_apply for type conversion
- Add comprehensive test suite with 46 tests
- Update lib.rs and mod.rs exports
- Regenerate Node.js bindings and update index.ts exports
- Update npm platform packages version