### PR TITLE
feat(WOR-TSK-199): implement execute command types for Node.js bindings

### DIFF
--- a/crates/node/Cargo.lock
+++ b/crates/node/Cargo.lock
@@ -2067,7 +2067,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "sublime_cli_tools"
-version = "0.0.29"
+version = "0.0.31"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "sublime_pkg_tools"
-version = "0.0.20"
+version = "0.0.22"
 dependencies = [
  "async-trait",
  "base64 0.21.7",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -69,9 +69,9 @@ napi = { version = "3.6.0", features = ["async", "tokio_rt", "napi9", "serde-jso
 napi-derive = "3.4.0"
 
 # Workspace crates - using path dependencies
-sublime_cli_tools = { version = "0.0.29", path = "../cli" }
+sublime_cli_tools = { version = "0.0.31", path = "../cli" }
 sublime_git_tools = { version = "0.0.15", path = "../git" }
-sublime_pkg_tools = { version = "0.0.20", path = "../pkg" }
+sublime_pkg_tools = { version = "0.0.22", path = "../pkg" }
 sublime_standard_tools = { version = "0.0.15", path = "../standard" }
 
 # Serialization

--- a/crates/node/src/tests.rs
+++ b/crates/node/src/tests.rs
@@ -4081,3 +4081,608 @@ mod bump_types_tests {
         assert!(json.contains("\"snapshot_version\":\"1.0.0-snapshot.abc\""));
     }
 }
+
+// =============================================================================
+// Execute Types Tests (Story 6.2)
+// =============================================================================
+
+/// Tests for execute command type definitions.
+#[cfg(test)]
+mod execute_types_tests {
+    use crate::error::ErrorInfo;
+    use crate::types::execute::{
+        ExecuteApiResponse, ExecuteData, ExecuteParams, ExecuteSummary, PackageExecutionResult,
+    };
+
+    // ========================================================================
+    // ExecuteParams Tests
+    // ========================================================================
+
+    #[test]
+    fn test_execute_params_new() {
+        let params = ExecuteParams::new("/workspace", "npm:test");
+
+        assert_eq!(params.root, "/workspace");
+        assert_eq!(params.cmd, "npm:test");
+        assert!(params.filter_package.is_none());
+        assert!(params.affected.is_none());
+        assert!(params.since.is_none());
+        assert!(params.until.is_none());
+        assert!(params.branch.is_none());
+        assert!(params.parallel.is_none());
+        assert!(params.args.is_none());
+        assert!(params.timeout_secs.is_none());
+        assert!(params.per_package_timeout_secs.is_none());
+    }
+
+    #[test]
+    fn test_execute_params_builder_chain() {
+        let params = ExecuteParams::new("/workspace", "npm:test")
+            .with_filter_package(vec!["@scope/core".to_string()])
+            .with_parallel(true)
+            .with_timeout_secs(300)
+            .with_per_package_timeout_secs(60)
+            .with_args(vec!["--coverage".to_string()]);
+
+        assert_eq!(params.root, "/workspace");
+        assert_eq!(params.cmd, "npm:test");
+        assert_eq!(params.filter_package, Some(vec!["@scope/core".to_string()]));
+        assert_eq!(params.parallel, Some(true));
+        assert_eq!(params.timeout_secs, Some(300));
+        assert_eq!(params.per_package_timeout_secs, Some(60));
+        assert_eq!(params.args, Some(vec!["--coverage".to_string()]));
+    }
+
+    #[test]
+    fn test_execute_params_affected_options() {
+        let params = ExecuteParams::new("/workspace", "npm:test")
+            .with_affected(true)
+            .with_branch("main")
+            .with_since("HEAD~5")
+            .with_until("HEAD");
+
+        assert_eq!(params.affected, Some(true));
+        assert_eq!(params.branch, Some("main".to_string()));
+        assert_eq!(params.since, Some("HEAD~5".to_string()));
+        assert_eq!(params.until, Some("HEAD".to_string()));
+    }
+
+    #[test]
+    fn test_execute_params_has_filter_package() {
+        let params_none = ExecuteParams::new(".", "npm:test");
+        assert!(!params_none.has_filter_package());
+
+        let params_empty = ExecuteParams::new(".", "npm:test").with_filter_package(vec![]);
+        assert!(!params_empty.has_filter_package());
+
+        let params_with_packages =
+            ExecuteParams::new(".", "npm:test").with_filter_package(vec!["pkg".to_string()]);
+        assert!(params_with_packages.has_filter_package());
+    }
+
+    #[test]
+    fn test_execute_params_is_affected() {
+        let params_none = ExecuteParams::new(".", "npm:test");
+        assert!(!params_none.is_affected());
+
+        let params_false = ExecuteParams::new(".", "npm:test").with_affected(false);
+        assert!(!params_false.is_affected());
+
+        let params_true = ExecuteParams::new(".", "npm:test").with_affected(true);
+        assert!(params_true.is_affected());
+    }
+
+    #[test]
+    fn test_execute_params_is_parallel() {
+        let params_none = ExecuteParams::new(".", "npm:test");
+        assert!(!params_none.is_parallel());
+
+        let params_false = ExecuteParams::new(".", "npm:test").with_parallel(false);
+        assert!(!params_false.is_parallel());
+
+        let params_true = ExecuteParams::new(".", "npm:test").with_parallel(true);
+        assert!(params_true.is_parallel());
+    }
+
+    #[test]
+    fn test_execute_params_clone() {
+        let params =
+            ExecuteParams::new("/workspace", "npm:test").with_parallel(true).with_timeout_secs(300);
+        let cloned = params.clone();
+
+        assert_eq!(cloned.root, params.root);
+        assert_eq!(cloned.cmd, params.cmd);
+        assert_eq!(cloned.parallel, params.parallel);
+        assert_eq!(cloned.timeout_secs, params.timeout_secs);
+    }
+
+    #[test]
+    fn test_execute_params_serialize() {
+        let params =
+            ExecuteParams::new("/workspace", "npm:test").with_parallel(true).with_timeout_secs(300);
+        let json = serde_json::to_string(&params).unwrap_or_default();
+
+        assert!(json.contains("\"root\":\"/workspace\""));
+        assert!(json.contains("\"cmd\":\"npm:test\""));
+        assert!(json.contains("\"parallel\":true"));
+        assert!(json.contains("\"timeout_secs\":300"));
+        // Optional fields that are None should not be present
+        assert!(!json.contains("\"filter_package\""));
+        assert!(!json.contains("\"affected\""));
+    }
+
+    // ========================================================================
+    // PackageExecutionResult Tests
+    // ========================================================================
+
+    #[test]
+    fn test_package_execution_result_new() {
+        let result = PackageExecutionResult::new("@scope/core", true, 0, 1500.0);
+
+        assert_eq!(result.package, "@scope/core");
+        assert!(result.success);
+        assert_eq!(result.exit_code, 0);
+        assert!((result.duration_ms - 1500.0).abs() < f64::EPSILON);
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn test_package_execution_result_success() {
+        let result = PackageExecutionResult::success("@scope/core", 2000.0);
+
+        assert_eq!(result.package, "@scope/core");
+        assert!(result.success);
+        assert_eq!(result.exit_code, 0);
+        assert!((result.duration_ms - 2000.0).abs() < f64::EPSILON);
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn test_package_execution_result_failure() {
+        let result = PackageExecutionResult::failure("@scope/core", 1, 500.0, "Test failed");
+
+        assert_eq!(result.package, "@scope/core");
+        assert!(!result.success);
+        assert_eq!(result.exit_code, 1);
+        assert!((result.duration_ms - 500.0).abs() < f64::EPSILON);
+        assert_eq!(result.error, Some("Test failed".to_string()));
+    }
+
+    #[test]
+    fn test_package_execution_result_with_error() {
+        let result = PackageExecutionResult::new("@scope/core", false, 1, 500.0)
+            .with_error("Command not found");
+
+        assert!(!result.success);
+        assert_eq!(result.error, Some("Command not found".to_string()));
+    }
+
+    #[test]
+    fn test_package_execution_result_clone() {
+        let result = PackageExecutionResult::failure("@scope/core", 1, 500.0, "Error");
+        let cloned = result.clone();
+
+        assert_eq!(cloned.package, result.package);
+        assert_eq!(cloned.success, result.success);
+        assert_eq!(cloned.exit_code, result.exit_code);
+        assert!((cloned.duration_ms - result.duration_ms).abs() < f64::EPSILON);
+        assert_eq!(cloned.error, result.error);
+    }
+
+    #[test]
+    fn test_package_execution_result_serialize() {
+        let result = PackageExecutionResult::failure("@scope/core", 1, 500.0, "Error");
+        let json = serde_json::to_string(&result).unwrap_or_default();
+
+        assert!(json.contains("\"package\":\"@scope/core\""));
+        assert!(json.contains("\"success\":false"));
+        assert!(json.contains("\"exit_code\":1"));
+        assert!(json.contains("\"duration_ms\":500"));
+        assert!(json.contains("\"error\":\"Error\""));
+    }
+
+    #[test]
+    fn test_package_execution_result_serialize_without_error() {
+        let result = PackageExecutionResult::success("@scope/core", 1500.0);
+        let json = serde_json::to_string(&result).unwrap_or_default();
+
+        assert!(json.contains("\"package\":\"@scope/core\""));
+        assert!(json.contains("\"success\":true"));
+        // error field should not be present when None
+        assert!(!json.contains("\"error\""));
+    }
+
+    // ========================================================================
+    // ExecuteSummary Tests
+    // ========================================================================
+
+    #[test]
+    fn test_execute_summary_new() {
+        let summary = ExecuteSummary::new(5, 4, 1, 15000.0);
+
+        assert_eq!(summary.total, 5);
+        assert_eq!(summary.succeeded, 4);
+        assert_eq!(summary.failed, 1);
+        assert!((summary.total_duration_ms - 15000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_execute_summary_empty() {
+        let summary = ExecuteSummary::empty();
+
+        assert_eq!(summary.total, 0);
+        assert_eq!(summary.succeeded, 0);
+        assert_eq!(summary.failed, 0);
+        assert!((summary.total_duration_ms - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_execute_summary_from_results() {
+        let results = vec![
+            PackageExecutionResult::success("pkg1", 1000.0),
+            PackageExecutionResult::success("pkg2", 500.0),
+            PackageExecutionResult::failure("pkg3", 1, 300.0, "Error"),
+        ];
+        let summary = ExecuteSummary::from_results(&results);
+
+        assert_eq!(summary.total, 3);
+        assert_eq!(summary.succeeded, 2);
+        assert_eq!(summary.failed, 1);
+        assert!((summary.total_duration_ms - 1800.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_execute_summary_from_results_empty() {
+        let results: Vec<PackageExecutionResult> = vec![];
+        let summary = ExecuteSummary::from_results(&results);
+
+        assert_eq!(summary.total, 0);
+        assert_eq!(summary.succeeded, 0);
+        assert_eq!(summary.failed, 0);
+        assert!((summary.total_duration_ms - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_execute_summary_all_succeeded() {
+        let all_pass = ExecuteSummary::new(3, 3, 0, 1000.0);
+        assert!(all_pass.all_succeeded());
+
+        let some_fail = ExecuteSummary::new(3, 2, 1, 1000.0);
+        assert!(!some_fail.all_succeeded());
+
+        let empty = ExecuteSummary::empty();
+        assert!(!empty.all_succeeded());
+    }
+
+    #[test]
+    fn test_execute_summary_has_failures() {
+        let all_pass = ExecuteSummary::new(3, 3, 0, 1000.0);
+        assert!(!all_pass.has_failures());
+
+        let some_fail = ExecuteSummary::new(3, 2, 1, 1000.0);
+        assert!(some_fail.has_failures());
+
+        let all_fail = ExecuteSummary::new(3, 0, 3, 1000.0);
+        assert!(all_fail.has_failures());
+    }
+
+    #[test]
+    fn test_execute_summary_clone() {
+        let summary = ExecuteSummary::new(5, 4, 1, 15000.0);
+        let cloned = summary.clone();
+
+        assert_eq!(cloned.total, summary.total);
+        assert_eq!(cloned.succeeded, summary.succeeded);
+        assert_eq!(cloned.failed, summary.failed);
+        assert!((cloned.total_duration_ms - summary.total_duration_ms).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_execute_summary_serialize() {
+        let summary = ExecuteSummary::new(5, 4, 1, 15000.0);
+        let json = serde_json::to_string(&summary).unwrap_or_default();
+
+        assert!(json.contains("\"total\":5"));
+        assert!(json.contains("\"succeeded\":4"));
+        assert!(json.contains("\"failed\":1"));
+        assert!(json.contains("\"total_duration_ms\":15000"));
+    }
+
+    // ========================================================================
+    // ExecuteData Tests
+    // ========================================================================
+
+    #[test]
+    fn test_execute_data_new() {
+        let results = vec![PackageExecutionResult::success("pkg1", 1000.0)];
+        let summary = ExecuteSummary::new(1, 1, 0, 1000.0);
+        let data = ExecuteData::new("npm:test", results, summary);
+
+        assert_eq!(data.command, "npm:test");
+        assert_eq!(data.results.len(), 1);
+        assert_eq!(data.summary.total, 1);
+    }
+
+    #[test]
+    fn test_execute_data_from_results() {
+        let results = vec![
+            PackageExecutionResult::success("pkg1", 1000.0),
+            PackageExecutionResult::failure("pkg2", 1, 500.0, "Error"),
+        ];
+        let data = ExecuteData::from_results("npm:build", results);
+
+        assert_eq!(data.command, "npm:build");
+        assert_eq!(data.results.len(), 2);
+        assert_eq!(data.summary.total, 2);
+        assert_eq!(data.summary.succeeded, 1);
+        assert_eq!(data.summary.failed, 1);
+        assert!((data.summary.total_duration_ms - 1500.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_execute_data_empty() {
+        let data = ExecuteData::empty("npm:lint");
+
+        assert_eq!(data.command, "npm:lint");
+        assert!(data.results.is_empty());
+        assert_eq!(data.summary.total, 0);
+    }
+
+    #[test]
+    fn test_execute_data_package_count() {
+        let data = ExecuteData::from_results(
+            "npm:test",
+            vec![
+                PackageExecutionResult::success("pkg1", 1000.0),
+                PackageExecutionResult::success("pkg2", 500.0),
+            ],
+        );
+
+        assert_eq!(data.package_count(), 2);
+    }
+
+    #[test]
+    fn test_execute_data_all_succeeded() {
+        let all_pass = ExecuteData::from_results(
+            "npm:test",
+            vec![
+                PackageExecutionResult::success("pkg1", 1000.0),
+                PackageExecutionResult::success("pkg2", 500.0),
+            ],
+        );
+        assert!(all_pass.all_succeeded());
+
+        let some_fail = ExecuteData::from_results(
+            "npm:test",
+            vec![
+                PackageExecutionResult::success("pkg1", 1000.0),
+                PackageExecutionResult::failure("pkg2", 1, 500.0, "Error"),
+            ],
+        );
+        assert!(!some_fail.all_succeeded());
+    }
+
+    #[test]
+    fn test_execute_data_has_failures() {
+        let all_pass = ExecuteData::from_results(
+            "npm:test",
+            vec![PackageExecutionResult::success("pkg1", 1000.0)],
+        );
+        assert!(!all_pass.has_failures());
+
+        let some_fail = ExecuteData::from_results(
+            "npm:test",
+            vec![PackageExecutionResult::failure("pkg1", 1, 500.0, "Error")],
+        );
+        assert!(some_fail.has_failures());
+    }
+
+    #[test]
+    fn test_execute_data_clone() {
+        let data = ExecuteData::from_results(
+            "npm:test",
+            vec![PackageExecutionResult::success("pkg1", 1000.0)],
+        );
+        let cloned = data.clone();
+
+        assert_eq!(cloned.command, data.command);
+        assert_eq!(cloned.results.len(), data.results.len());
+        assert_eq!(cloned.summary.total, data.summary.total);
+    }
+
+    #[test]
+    fn test_execute_data_serialize() {
+        let data = ExecuteData::from_results(
+            "npm:test",
+            vec![PackageExecutionResult::success("@scope/core", 1000.0)],
+        );
+        let json = serde_json::to_string(&data).unwrap_or_default();
+
+        assert!(json.contains("\"command\":\"npm:test\""));
+        assert!(json.contains("\"package\":\"@scope/core\""));
+        assert!(json.contains("\"total\":1"));
+        assert!(json.contains("\"succeeded\":1"));
+    }
+
+    // ========================================================================
+    // ExecuteApiResponse Tests
+    // ========================================================================
+
+    #[test]
+    fn test_execute_api_response_success() {
+        let data = ExecuteData::empty("npm:test");
+        let response = ExecuteApiResponse::success(data);
+
+        assert!(response.success);
+        assert!(response.data.is_some());
+        assert!(response.error.is_none());
+        assert!(response.is_success());
+        assert!(!response.is_failure());
+    }
+
+    #[test]
+    fn test_execute_api_response_failure() {
+        let error = ErrorInfo::validation("Invalid command", Some("cmd"));
+        let response = ExecuteApiResponse::failure(error);
+
+        assert!(!response.success);
+        assert!(response.data.is_none());
+        assert!(response.error.is_some());
+        assert!(!response.is_success());
+        assert!(response.is_failure());
+    }
+
+    #[test]
+    fn test_execute_api_response_failure_with_different_error_codes() {
+        // EVALIDATION
+        let validation_error = ErrorInfo::validation("Invalid root", Some("root"));
+        let validation_response = ExecuteApiResponse::failure(validation_error);
+        assert_eq!(
+            validation_response.error.as_ref().map(|e| e.code.as_str()),
+            Some("EVALIDATION")
+        );
+
+        // ENOENT (Entity Not Found - Unix/Node.js standard)
+        let not_found_error = ErrorInfo::not_found("Path not found", Some("root"));
+        let not_found_response = ExecuteApiResponse::failure(not_found_error);
+        assert_eq!(not_found_response.error.as_ref().map(|e| e.code.as_str()), Some("ENOENT"));
+
+        // ETIMEOUT
+        let timeout_error = ErrorInfo::timeout("Operation timed out");
+        let timeout_response = ExecuteApiResponse::failure(timeout_error);
+        assert_eq!(timeout_response.error.as_ref().map(|e| e.code.as_str()), Some("ETIMEOUT"));
+    }
+
+    #[test]
+    fn test_execute_api_response_clone() {
+        let data = ExecuteData::empty("npm:test");
+        let response = ExecuteApiResponse::success(data);
+        let cloned = response.clone();
+
+        assert_eq!(cloned.success, response.success);
+        assert!(cloned.data.is_some());
+    }
+
+    #[test]
+    fn test_execute_api_response_serialize_success() {
+        let data = ExecuteData::empty("npm:test");
+        let response = ExecuteApiResponse::success(data);
+        let json = serde_json::to_string(&response).unwrap_or_default();
+
+        assert!(json.contains("\"success\":true"));
+        assert!(json.contains("\"command\":\"npm:test\""));
+        assert!(!json.contains("\"error\""));
+    }
+
+    #[test]
+    fn test_execute_api_response_serialize_failure() {
+        let error = ErrorInfo::validation("Invalid command", Some("cmd"));
+        let response = ExecuteApiResponse::failure(error);
+        let json = serde_json::to_string(&response).unwrap_or_default();
+
+        assert!(json.contains("\"success\":false"));
+        assert!(json.contains("\"code\":\"EVALIDATION\""));
+        assert!(!json.contains("\"data\""));
+    }
+
+    #[test]
+    fn test_execute_api_response_with_full_data() {
+        let results = vec![
+            PackageExecutionResult::success("@scope/core", 1500.0),
+            PackageExecutionResult::failure("@scope/utils", 1, 800.0, "Test failed"),
+        ];
+        let data = ExecuteData::from_results("npm:test", results);
+        let response = ExecuteApiResponse::success(data);
+
+        assert!(response.success);
+        let data = response.data.as_ref().unwrap();
+        assert_eq!(data.command, "npm:test");
+        assert_eq!(data.results.len(), 2);
+        assert_eq!(data.summary.total, 2);
+        assert_eq!(data.summary.succeeded, 1);
+        assert_eq!(data.summary.failed, 1);
+    }
+
+    // ========================================================================
+    // Integration Tests
+    // ========================================================================
+
+    #[test]
+    fn test_execute_complete_scenario_parallel() {
+        // Simulate parallel execution on affected packages
+        let params = ExecuteParams::new("/workspace", "npm:test")
+            .with_affected(true)
+            .with_branch("main")
+            .with_parallel(true)
+            .with_timeout_secs(300)
+            .with_per_package_timeout_secs(60);
+
+        assert!(params.is_affected());
+        assert!(params.is_parallel());
+        assert!(!params.has_filter_package());
+
+        // Simulate results
+        let results = vec![
+            PackageExecutionResult::success("@scope/core", 2000.0),
+            PackageExecutionResult::success("@scope/utils", 1500.0),
+            PackageExecutionResult::success("@scope/cli", 3000.0),
+        ];
+        let data = ExecuteData::from_results(&params.cmd, results);
+        let response = ExecuteApiResponse::success(data);
+
+        assert!(response.is_success());
+        let data = response.data.as_ref().unwrap();
+        assert!(data.all_succeeded());
+        assert!(!data.has_failures());
+        assert_eq!(data.summary.total, 3);
+        assert_eq!(data.summary.succeeded, 3);
+    }
+
+    #[test]
+    fn test_execute_complete_scenario_filtered() {
+        // Simulate execution on specific packages
+        let params = ExecuteParams::new("/workspace", "npm:build")
+            .with_filter_package(vec!["@scope/core".to_string(), "@scope/utils".to_string()])
+            .with_parallel(false);
+
+        assert!(!params.is_affected());
+        assert!(!params.is_parallel());
+        assert!(params.has_filter_package());
+
+        // Simulate results with one failure
+        let results = vec![
+            PackageExecutionResult::success("@scope/core", 5000.0),
+            PackageExecutionResult::failure(
+                "@scope/utils",
+                1,
+                2000.0,
+                "Build failed: missing dependency",
+            ),
+        ];
+        let data = ExecuteData::from_results(&params.cmd, results);
+        let response = ExecuteApiResponse::success(data);
+
+        assert!(response.is_success());
+        let data = response.data.as_ref().unwrap();
+        assert!(!data.all_succeeded());
+        assert!(data.has_failures());
+        assert_eq!(data.summary.succeeded, 1);
+        assert_eq!(data.summary.failed, 1);
+    }
+
+    #[test]
+    fn test_execute_system_command() {
+        // Test with a system command (not npm script)
+        let params =
+            ExecuteParams::new("/workspace", "echo hello").with_args(vec!["world".to_string()]);
+
+        assert_eq!(params.cmd, "echo hello");
+        assert_eq!(params.args, Some(vec!["world".to_string()]));
+
+        let results = vec![PackageExecutionResult::success("root", 50.0)];
+        let data = ExecuteData::from_results(&params.cmd, results);
+
+        assert_eq!(data.command, "echo hello");
+        assert!((data.summary.total_duration_ms - 50.0).abs() < f64::EPSILON);
+    }
+}

--- a/crates/node/src/types/execute.rs
+++ b/crates/node/src/types/execute.rs
@@ -1,40 +1,53 @@
-//! Execute command type definitions.
+//! Execute command type definitions for Node.js bindings.
 //!
 //! # What
 //!
-//! This module contains type definitions for the execute command, including
-//! parameter structures and response data types. The execute command runs
+//! This module defines all NAPI-compatible type structures for the execute command,
+//! including input parameters and response data types. The execute command runs
 //! arbitrary commands across workspace packages with filtering, parallelism,
 //! and timeout support.
 //!
 //! # How
 //!
-//! Types are defined with `#[napi(object)]` attribute to be exposed as
-//! JavaScript objects. The module provides:
+//! Types are defined with the `#[napi(object)]` attribute to be automatically
+//! exposed as JavaScript objects. The module provides:
 //!
-//! - `ExecuteParams`: Input parameters for the execute command
-//! - `ExecuteData`: Response data containing execution results
+//! - **Input Parameters**: `ExecuteParams`
+//! - **Response Data**: `ExecuteData`, `PackageExecutionResult`, `ExecuteSummary`
+//! - **API Response**: `ExecuteApiResponse` for consistent success/error handling
+//!
+//! All types implement `Clone`, `Debug`, and `Serialize` for flexibility in
+//! testing and serialization scenarios.
 //!
 //! # Why
 //!
 //! The execute command enables running scripts across multiple packages with
 //! intelligent filtering (affected packages, specific packages) and execution
 //! control (parallel, timeout). It's essential for CI/CD workflows and
-//! development tasks.
+//! development tasks. These types provide:
+//!
+//! - **Type safety**: Strong typing for JavaScript/TypeScript consumers
+//! - **Documentation**: Self-documenting API through TypeScript definitions
+//! - **Consistency**: Matches the CLI JSON output structure for compatibility
+//! - **Validation**: Enables parameter validation before CLI execution
+//! - **Timeout control**: Configurable timeouts at global and per-package level
 //!
 //! # Examples
+//!
+//! ## TypeScript Usage
 //!
 //! ```typescript
 //! import { execute, ExecuteParams, ExecuteData } from '@websublime/workspace-tools';
 //!
-//! // Run tests on affected packages
+//! // Run tests on affected packages with timeout
 //! const params: ExecuteParams = {
 //!   root: '.',
-//!   cmd: 'npm test',
+//!   cmd: 'npm:test',
 //!   affected: true,
 //!   branch: 'main',
 //!   parallel: true,
-//!   timeoutSecs: 300
+//!   timeoutSecs: 300,           // 5 minutes total timeout
+//!   perPackageTimeoutSecs: 60   // 1 minute per package
 //! };
 //! const result = await execute(params);
 //!
@@ -42,18 +55,20 @@
 //!   const data: ExecuteData = result.data;
 //!   console.log(`Command: ${data.command}`);
 //!   console.log(`Packages: ${data.results.length}`);
-//!   console.log(`Summary: ${data.summary.successful}/${data.summary.total} succeeded`);
+//!   console.log(`Summary: ${data.summary.succeeded}/${data.summary.total} succeeded`);
 //!
 //!   for (const pkg of data.results) {
 //!     const icon = pkg.success ? '✓' : '✗';
-//!     console.log(`${icon} ${pkg.packageName}: ${pkg.exitCode}`);
+//!     console.log(`${icon} ${pkg.package}: exit code ${pkg.exitCode}`);
 //!   }
+//! } else {
+//!   console.error(`Error [${result.error.code}]: ${result.error.message}`);
 //! }
 //!
 //! // Run build on specific packages
 //! const buildResult = await execute({
 //!   root: '.',
-//!   cmd: 'npm run build',
+//!   cmd: 'npm:build',
 //!   filterPackage: ['@scope/core', '@scope/utils'],
 //!   parallel: true
 //! });
@@ -61,50 +76,1210 @@
 //! // Run lint with per-package timeout
 //! const lintResult = await execute({
 //!   root: '.',
-//!   cmd: 'npm run lint',
+//!   cmd: 'npm:lint',
 //!   perPackageTimeoutSecs: 60
 //! });
+//!
+//! // Run system command across all packages
+//! const systemResult = await execute({
+//!   root: '.',
+//!   cmd: 'ls -la',
+//!   args: ['-h']  // Additional arguments
+//! });
+//! ```
+//!
+//! ## Rust Usage (Internal)
+//!
+//! ```rust,ignore
+//! use sublime_node_tools::types::execute::{
+//!     ExecuteParams, ExecuteData, PackageExecutionResult, ExecuteSummary
+//! };
+//!
+//! // Creating params for validation
+//! let params = ExecuteParams::new(".", "npm:test")
+//!     .with_affected(true)
+//!     .with_parallel(true)
+//!     .with_timeout_secs(300);
+//!
+//! // Constructing response data
+//! let result = PackageExecutionResult::new("@scope/pkg", true, 0, 1500);
+//! let summary = ExecuteSummary::new(1, 1, 0, 1500);
+//! let data = ExecuteData::new("npm:test", vec![result], summary);
 //! ```
 
-// TODO: will be implemented on story 6.2 - Execute Types
-// This module will contain:
-//
-// NAPI-specific types:
-// - ExecuteParams: {
-//     root: string,                  // Workspace root path
-//     cmd: string,                   // Command to execute
-//     filterPackage?: string[],      // Filter by package names (mutually exclusive with affected)
-//     affected?: boolean,            // Run on affected packages only (mutually exclusive with filterPackage)
-//     branch?: string,               // Base branch for affected detection (default: main)
-//     parallel?: boolean,            // Run commands in parallel
-//     timeoutSecs?: number,          // Global timeout for entire operation
-//     perPackageTimeoutSecs?: number // Timeout per package execution
-//   }
-// - ExecuteData: {
-//     command: string,               // The command that was executed
-//     results: PackageExecutionResult[],  // Results per package
-//     summary: ExecutionSummary      // Overall execution summary
-//   }
-//
-// Shared types:
-// - PackageExecutionResult: {
-//     packageName: string,           // Name of the package
-//     packagePath: string,           // Path to the package
-//     success: boolean,              // Whether execution succeeded
-//     exitCode: number,              // Exit code of the command
-//     stdout: string,                // Standard output
-//     stderr: string,                // Standard error
-//     durationMs: number,            // Execution duration in milliseconds
-//     timedOut: boolean              // Whether execution timed out
-//   }
-// - ExecutionSummary: {
-//     total: number,                 // Total packages processed
-//     successful: number,            // Packages with successful execution
-//     failed: number,                // Packages with failed execution
-//     skipped: number,               // Packages that were skipped
-//     timedOut: number,              // Packages that timed out
-//     totalDurationMs: number        // Total duration in milliseconds
-//   }
-//
-// Note: filterPackage and affected are mutually exclusive parameters.
-// Validation should ensure only one is provided at a time.
+use napi_derive::napi;
+use serde::Serialize;
+
+use crate::error::ErrorInfo;
+
+// ============================================================================
+// Input Parameters
+// ============================================================================
+
+/// Input parameters for the execute command.
+///
+/// This structure defines the parameters for running commands across workspace
+/// packages. It supports filtering by package names or affected packages,
+/// parallel execution, and configurable timeouts.
+///
+/// # Fields
+///
+/// - `root`: The workspace root directory path (required)
+/// - `cmd`: The command to execute (required)
+/// - `filter_package`: Filter by specific package names
+/// - `affected`: Execute only on affected packages
+/// - `since`: Git reference for affected detection start
+/// - `until`: Git reference for affected detection end
+/// - `branch`: Base branch for affected comparison
+/// - `parallel`: Run commands in parallel
+/// - `args`: Additional arguments to pass to the command
+/// - `timeout_secs`: Global timeout in seconds
+/// - `per_package_timeout_secs`: Per-package timeout in seconds
+///
+/// # Mutual Exclusion
+///
+/// `filter_package` and `affected` are mutually exclusive. Only one can be
+/// specified at a time. Validation should ensure this constraint is enforced.
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface ExecuteParams {
+///   root: string;
+///   cmd: string;
+///   filterPackage?: string[];
+///   affected?: boolean;
+///   since?: string;
+///   until?: string;
+///   branch?: string;
+///   parallel?: boolean;
+///   args?: string[];
+///   timeoutSecs?: number;
+///   perPackageTimeoutSecs?: number;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// // Run tests on affected packages
+/// const params: ExecuteParams = {
+///   root: '.',
+///   cmd: 'npm:test',
+///   affected: true,
+///   branch: 'main',
+///   parallel: true
+/// };
+///
+/// // Run build on specific packages with timeout
+/// const buildParams: ExecuteParams = {
+///   root: '/path/to/workspace',
+///   cmd: 'npm:build',
+///   filterPackage: ['@scope/core', '@scope/utils'],
+///   timeoutSecs: 600,
+///   perPackageTimeoutSecs: 120
+/// };
+///
+/// // Run system command with extra arguments
+/// const systemParams: ExecuteParams = {
+///   root: '.',
+///   cmd: 'echo',
+///   args: ['Hello', 'World']
+/// };
+/// ```
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecuteParams {
+    /// Workspace root directory path.
+    ///
+    /// This is the absolute or relative path to the root of the workspace.
+    /// For monorepos, this should point to the root where the package manager
+    /// configuration is located.
+    pub root: String,
+
+    /// Command to execute.
+    ///
+    /// Supports two formats:
+    /// - `npm:<script>`: Runs an npm script (e.g., `npm:lint`, `npm:build`)
+    /// - Plain command: Runs a system command (e.g., `ls -la`, `node index.js`)
+    ///
+    /// For npm scripts, the appropriate package manager (npm, yarn, pnpm, bun)
+    /// is automatically detected and used.
+    pub cmd: String,
+
+    /// Filter packages to run command on.
+    ///
+    /// When provided, only executes the command in the specified packages.
+    /// Package names should match exactly (e.g., `@scope/package`).
+    ///
+    /// Mutually exclusive with `affected`.
+    #[napi(ts_type = "string[] | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter_package: Option<Vec<String>>,
+
+    /// Execute only on packages affected by changes.
+    ///
+    /// When `true`, automatically detects packages with changes and runs
+    /// commands only on them. By default, analyzes working directory changes
+    /// (staged + unstaged).
+    ///
+    /// Use `since`/`until` for commit range analysis, or `branch` for
+    /// branch comparison.
+    ///
+    /// Mutually exclusive with `filter_package`.
+    #[napi(ts_type = "boolean | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub affected: Option<bool>,
+
+    /// Since commit/branch/tag for affected detection.
+    ///
+    /// Used with `affected: true` to analyze changes since this Git reference.
+    /// If not specified with `affected`, analyzes working directory changes.
+    ///
+    /// Example: `"HEAD~5"`, `"v1.0.0"`, `"main"`
+    #[napi(ts_type = "string | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub since: Option<String>,
+
+    /// Until commit/branch/tag for affected detection.
+    ///
+    /// Used with `affected: true` to analyze changes until this Git reference.
+    /// Defaults to `HEAD` when `since` is specified.
+    ///
+    /// Example: `"HEAD"`, `"v2.0.0"`
+    #[napi(ts_type = "string | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub until: Option<String>,
+
+    /// Compare against branch for affected detection.
+    ///
+    /// Used with `affected: true` to compare current branch against the
+    /// target branch. Detects packages changed between current branch and
+    /// the specified branch.
+    ///
+    /// Example: `"main"`, `"develop"`
+    #[napi(ts_type = "string | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+
+    /// Run commands in parallel across packages.
+    ///
+    /// When `true`, all package commands run concurrently. By default,
+    /// commands run sequentially.
+    ///
+    /// Note: Parallel execution may interleave output from different packages.
+    #[napi(ts_type = "boolean | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<bool>,
+
+    /// Additional arguments passed to the command.
+    ///
+    /// These arguments are appended to the command after the base command
+    /// and any npm script arguments.
+    ///
+    /// Example: `["--coverage", "--verbose"]`
+    #[napi(ts_type = "string[] | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<Vec<String>>,
+
+    /// Timeout for the entire execute operation in seconds.
+    ///
+    /// This is the global timeout for executing commands across all packages.
+    /// A value of `0` is invalid; use `None` to indicate no timeout.
+    ///
+    /// If not provided, the default from the configuration is used (typically
+    /// 300 seconds / 5 minutes).
+    ///
+    /// Note: This parameter overrides the configuration value when provided.
+    #[napi(ts_type = "number | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timeout_secs: Option<u32>,
+
+    /// Timeout per package execution in seconds.
+    ///
+    /// This is the timeout for executing the command in a single package.
+    /// A value of `0` is invalid; use `None` to indicate no per-package timeout.
+    ///
+    /// If not provided, the default from the configuration is used (typically
+    /// 60 seconds / 1 minute).
+    ///
+    /// Note: This parameter overrides the configuration value when provided.
+    #[napi(ts_type = "number | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub per_package_timeout_secs: Option<u32>,
+}
+
+#[allow(dead_code)]
+impl ExecuteParams {
+    /// Creates a new `ExecuteParams` with the required root and command.
+    ///
+    /// # Arguments
+    ///
+    /// * `root` - The workspace root directory path
+    /// * `cmd` - The command to execute
+    ///
+    /// # Returns
+    ///
+    /// A new `ExecuteParams` instance with default optional values.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::execute::ExecuteParams;
+    ///
+    /// let params = ExecuteParams::new(".", "npm:test");
+    /// assert_eq!(params.root, ".");
+    /// assert_eq!(params.cmd, "npm:test");
+    /// ```
+    #[must_use]
+    pub fn new(root: impl Into<String>, cmd: impl Into<String>) -> Self {
+        Self {
+            root: root.into(),
+            cmd: cmd.into(),
+            filter_package: None,
+            affected: None,
+            since: None,
+            until: None,
+            branch: None,
+            parallel: None,
+            args: None,
+            timeout_secs: None,
+            per_package_timeout_secs: None,
+        }
+    }
+
+    /// Sets the filter packages.
+    ///
+    /// # Arguments
+    ///
+    /// * `packages` - Package names to filter
+    ///
+    /// # Returns
+    ///
+    /// The modified `ExecuteParams` instance for method chaining.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let params = ExecuteParams::new(".", "npm:test")
+    ///     .with_filter_package(vec!["@scope/core".to_string()]);
+    /// ```
+    #[must_use]
+    pub fn with_filter_package(mut self, packages: Vec<String>) -> Self {
+        self.filter_package = Some(packages);
+        self
+    }
+
+    /// Sets the affected flag.
+    ///
+    /// # Arguments
+    ///
+    /// * `affected` - Whether to run on affected packages only
+    ///
+    /// # Returns
+    ///
+    /// The modified `ExecuteParams` instance for method chaining.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let params = ExecuteParams::new(".", "npm:test")
+    ///     .with_affected(true);
+    /// ```
+    #[must_use]
+    pub fn with_affected(mut self, affected: bool) -> Self {
+        self.affected = Some(affected);
+        self
+    }
+
+    /// Sets the since reference for affected detection.
+    ///
+    /// # Arguments
+    ///
+    /// * `since` - Git reference to start from
+    ///
+    /// # Returns
+    ///
+    /// The modified `ExecuteParams` instance for method chaining.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let params = ExecuteParams::new(".", "npm:test")
+    ///     .with_affected(true)
+    ///     .with_since("HEAD~5");
+    /// ```
+    #[must_use]
+    pub fn with_since(mut self, since: impl Into<String>) -> Self {
+        self.since = Some(since.into());
+        self
+    }
+
+    /// Sets the until reference for affected detection.
+    ///
+    /// # Arguments
+    ///
+    /// * `until` - Git reference to end at
+    ///
+    /// # Returns
+    ///
+    /// The modified `ExecuteParams` instance for method chaining.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let params = ExecuteParams::new(".", "npm:test")
+    ///     .with_affected(true)
+    ///     .with_since("v1.0.0")
+    ///     .with_until("v2.0.0");
+    /// ```
+    #[must_use]
+    pub fn with_until(mut self, until: impl Into<String>) -> Self {
+        self.until = Some(until.into());
+        self
+    }
+
+    /// Sets the branch for affected comparison.
+    ///
+    /// # Arguments
+    ///
+    /// * `branch` - Base branch to compare against
+    ///
+    /// # Returns
+    ///
+    /// The modified `ExecuteParams` instance for method chaining.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let params = ExecuteParams::new(".", "npm:test")
+    ///     .with_affected(true)
+    ///     .with_branch("main");
+    /// ```
+    #[must_use]
+    pub fn with_branch(mut self, branch: impl Into<String>) -> Self {
+        self.branch = Some(branch.into());
+        self
+    }
+
+    /// Sets the parallel execution flag.
+    ///
+    /// # Arguments
+    ///
+    /// * `parallel` - Whether to run commands in parallel
+    ///
+    /// # Returns
+    ///
+    /// The modified `ExecuteParams` instance for method chaining.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let params = ExecuteParams::new(".", "npm:test")
+    ///     .with_parallel(true);
+    /// ```
+    #[must_use]
+    pub fn with_parallel(mut self, parallel: bool) -> Self {
+        self.parallel = Some(parallel);
+        self
+    }
+
+    /// Sets additional arguments for the command.
+    ///
+    /// # Arguments
+    ///
+    /// * `args` - Additional arguments to pass
+    ///
+    /// # Returns
+    ///
+    /// The modified `ExecuteParams` instance for method chaining.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let params = ExecuteParams::new(".", "npm:test")
+    ///     .with_args(vec!["--coverage".to_string()]);
+    /// ```
+    #[must_use]
+    pub fn with_args(mut self, args: Vec<String>) -> Self {
+        self.args = Some(args);
+        self
+    }
+
+    /// Sets the global timeout in seconds.
+    ///
+    /// # Arguments
+    ///
+    /// * `timeout_secs` - Timeout value in seconds
+    ///
+    /// # Returns
+    ///
+    /// The modified `ExecuteParams` instance for method chaining.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let params = ExecuteParams::new(".", "npm:test")
+    ///     .with_timeout_secs(300); // 5 minutes
+    /// ```
+    #[must_use]
+    pub fn with_timeout_secs(mut self, timeout_secs: u32) -> Self {
+        self.timeout_secs = Some(timeout_secs);
+        self
+    }
+
+    /// Sets the per-package timeout in seconds.
+    ///
+    /// # Arguments
+    ///
+    /// * `per_package_timeout_secs` - Per-package timeout value in seconds
+    ///
+    /// # Returns
+    ///
+    /// The modified `ExecuteParams` instance for method chaining.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let params = ExecuteParams::new(".", "npm:test")
+    ///     .with_per_package_timeout_secs(60); // 1 minute per package
+    /// ```
+    #[must_use]
+    pub fn with_per_package_timeout_secs(mut self, per_package_timeout_secs: u32) -> Self {
+        self.per_package_timeout_secs = Some(per_package_timeout_secs);
+        self
+    }
+
+    /// Checks if filter package is set.
+    ///
+    /// # Returns
+    ///
+    /// `true` if `filter_package` is `Some` with a non-empty vector.
+    #[must_use]
+    pub fn has_filter_package(&self) -> bool {
+        self.filter_package.as_ref().is_some_and(|p| !p.is_empty())
+    }
+
+    /// Checks if affected mode is enabled.
+    ///
+    /// # Returns
+    ///
+    /// `true` if `affected` is `Some(true)`.
+    #[must_use]
+    pub fn is_affected(&self) -> bool {
+        self.affected == Some(true)
+    }
+
+    /// Checks if parallel mode is enabled.
+    ///
+    /// # Returns
+    ///
+    /// `true` if `parallel` is `Some(true)`.
+    #[must_use]
+    pub fn is_parallel(&self) -> bool {
+        self.parallel == Some(true)
+    }
+}
+
+// ============================================================================
+// Response Data Types
+// ============================================================================
+
+/// Result for a single package execution.
+///
+/// Contains the outcome of executing a command in one package, including
+/// success status, exit code, duration, and any error message.
+///
+/// # Fields
+///
+/// - `package`: The package name
+/// - `success`: Whether execution succeeded
+/// - `exit_code`: Exit code from the command
+/// - `duration_ms`: Execution duration in milliseconds
+/// - `error`: Error message if execution failed
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface PackageExecutionResult {
+///   package: string;
+///   success: boolean;
+///   exitCode: number;
+///   durationMs: number;
+///   error?: string;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// // Successful execution
+/// const success: PackageExecutionResult = {
+///   package: '@scope/core',
+///   success: true,
+///   exitCode: 0,
+///   durationMs: 1500
+/// };
+///
+/// // Failed execution
+/// const failed: PackageExecutionResult = {
+///   package: '@scope/utils',
+///   success: false,
+///   exitCode: 1,
+///   durationMs: 500,
+///   error: 'Test suite failed with 3 failing tests'
+/// };
+/// ```
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct PackageExecutionResult {
+    /// Package name.
+    ///
+    /// The name of the package where the command was executed.
+    /// This matches the name in the package's `package.json`.
+    pub package: String,
+
+    /// Whether execution succeeded.
+    ///
+    /// - `true`: Command exited with code 0
+    /// - `false`: Command exited with non-zero code or errored
+    pub success: bool,
+
+    /// Exit code from the command.
+    ///
+    /// The process exit code returned by the command.
+    /// Typically `0` for success, non-zero for failure.
+    /// May be `-1` if the process was terminated or couldn't be started.
+    pub exit_code: i32,
+
+    /// Execution duration in milliseconds.
+    ///
+    /// The time taken to execute the command in this package,
+    /// measured from start to completion.
+    ///
+    /// Note: Uses `f64` for JavaScript compatibility. JavaScript numbers are
+    /// internally f64, which can represent integers up to 2^53 without precision
+    /// loss, more than sufficient for duration values.
+    pub duration_ms: f64,
+
+    /// Error message if execution failed.
+    ///
+    /// Contains error details when `success` is `false`.
+    /// May include stderr output or error descriptions.
+    #[napi(ts_type = "string | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[allow(dead_code)]
+impl PackageExecutionResult {
+    /// Creates a new successful `PackageExecutionResult`.
+    ///
+    /// # Arguments
+    ///
+    /// * `package` - The package name
+    /// * `success` - Whether execution succeeded
+    /// * `exit_code` - The command exit code
+    /// * `duration_ms` - Execution duration in milliseconds
+    ///
+    /// # Returns
+    ///
+    /// A new `PackageExecutionResult` instance.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::execute::PackageExecutionResult;
+    ///
+    /// let result = PackageExecutionResult::new("@scope/pkg", true, 0, 1500);
+    /// assert!(result.success);
+    /// ```
+    #[must_use]
+    pub fn new(
+        package: impl Into<String>,
+        success: bool,
+        exit_code: i32,
+        duration_ms: f64,
+    ) -> Self {
+        Self { package: package.into(), success, exit_code, duration_ms, error: None }
+    }
+
+    /// Creates a new successful execution result.
+    ///
+    /// # Arguments
+    ///
+    /// * `package` - The package name
+    /// * `duration_ms` - Execution duration in milliseconds
+    ///
+    /// # Returns
+    ///
+    /// A new `PackageExecutionResult` with success=true and exit_code=0.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let result = PackageExecutionResult::success("@scope/pkg", 1500);
+    /// assert!(result.success);
+    /// assert_eq!(result.exit_code, 0);
+    /// ```
+    #[must_use]
+    pub fn success(package: impl Into<String>, duration_ms: f64) -> Self {
+        Self::new(package, true, 0, duration_ms)
+    }
+
+    /// Creates a new failed execution result.
+    ///
+    /// # Arguments
+    ///
+    /// * `package` - The package name
+    /// * `exit_code` - The command exit code
+    /// * `duration_ms` - Execution duration in milliseconds
+    /// * `error` - Error message
+    ///
+    /// # Returns
+    ///
+    /// A new `PackageExecutionResult` with success=false.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let result = PackageExecutionResult::failure(
+    ///     "@scope/pkg",
+    ///     1,
+    ///     500,
+    ///     "Test failed"
+    /// );
+    /// assert!(!result.success);
+    /// assert_eq!(result.exit_code, 1);
+    /// ```
+    #[must_use]
+    pub fn failure(
+        package: impl Into<String>,
+        exit_code: i32,
+        duration_ms: f64,
+        error: impl Into<String>,
+    ) -> Self {
+        Self {
+            package: package.into(),
+            success: false,
+            exit_code,
+            duration_ms,
+            error: Some(error.into()),
+        }
+    }
+
+    /// Sets the error message.
+    ///
+    /// # Arguments
+    ///
+    /// * `error` - The error message
+    ///
+    /// # Returns
+    ///
+    /// The modified `PackageExecutionResult` instance for method chaining.
+    #[must_use]
+    pub fn with_error(mut self, error: impl Into<String>) -> Self {
+        self.error = Some(error.into());
+        self
+    }
+}
+
+/// Execution summary for all packages.
+///
+/// Provides aggregate statistics about command execution across all
+/// targeted packages, including counts and total duration.
+///
+/// # Fields
+///
+/// - `total`: Total number of packages
+/// - `succeeded`: Number of successful executions
+/// - `failed`: Number of failed executions
+/// - `total_duration_ms`: Total execution duration in milliseconds
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface ExecuteSummary {
+///   total: number;
+///   succeeded: number;
+///   failed: number;
+///   totalDurationMs: number;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// const summary: ExecuteSummary = {
+///   total: 5,
+///   succeeded: 4,
+///   failed: 1,
+///   totalDurationMs: 15000
+/// };
+///
+/// // Check if all succeeded
+/// if (summary.succeeded === summary.total) {
+///   console.log('All packages passed!');
+/// }
+/// ```
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecuteSummary {
+    /// Total number of packages processed.
+    ///
+    /// This is the count of all packages that were targeted for execution,
+    /// regardless of success or failure.
+    pub total: u32,
+
+    /// Number of successful executions.
+    ///
+    /// Count of packages where the command exited with code 0.
+    pub succeeded: u32,
+
+    /// Number of failed executions.
+    ///
+    /// Count of packages where the command exited with non-zero code
+    /// or encountered an error.
+    pub failed: u32,
+
+    /// Total execution duration in milliseconds.
+    ///
+    /// For sequential execution, this is the sum of all package durations.
+    /// For parallel execution, this is the wall-clock time from start to finish.
+    ///
+    /// Note: Uses `f64` for JavaScript compatibility. JavaScript numbers are
+    /// internally f64, which can represent integers up to 2^53 without precision
+    /// loss, more than sufficient for duration values.
+    pub total_duration_ms: f64,
+}
+
+#[allow(dead_code)]
+impl ExecuteSummary {
+    /// Creates a new `ExecuteSummary`.
+    ///
+    /// # Arguments
+    ///
+    /// * `total` - Total number of packages
+    /// * `succeeded` - Number of successful executions
+    /// * `failed` - Number of failed executions
+    /// * `total_duration_ms` - Total duration in milliseconds
+    ///
+    /// # Returns
+    ///
+    /// A new `ExecuteSummary` instance.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::execute::ExecuteSummary;
+    ///
+    /// let summary = ExecuteSummary::new(5, 4, 1, 15000);
+    /// assert_eq!(summary.total, 5);
+    /// assert_eq!(summary.succeeded, 4);
+    /// assert_eq!(summary.failed, 1);
+    /// ```
+    #[must_use]
+    pub fn new(total: u32, succeeded: u32, failed: u32, total_duration_ms: f64) -> Self {
+        Self { total, succeeded, failed, total_duration_ms }
+    }
+
+    /// Creates an empty `ExecuteSummary`.
+    ///
+    /// # Returns
+    ///
+    /// A new `ExecuteSummary` with all values set to zero.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let summary = ExecuteSummary::empty();
+    /// assert_eq!(summary.total, 0);
+    /// ```
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::new(0, 0, 0, 0.0)
+    }
+
+    /// Creates a summary from a collection of package results.
+    ///
+    /// # Arguments
+    ///
+    /// * `results` - Slice of package execution results
+    ///
+    /// # Returns
+    ///
+    /// A new `ExecuteSummary` computed from the results.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let results = vec![
+    ///     PackageExecutionResult::success("pkg1", 1000),
+    ///     PackageExecutionResult::failure("pkg2", 1, 500, "error"),
+    /// ];
+    /// let summary = ExecuteSummary::from_results(&results);
+    /// assert_eq!(summary.total, 2);
+    /// assert_eq!(summary.succeeded, 1);
+    /// assert_eq!(summary.failed, 1);
+    /// ```
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn from_results(results: &[PackageExecutionResult]) -> Self {
+        // Safe to truncate: In practice, workspaces don't have billions of packages.
+        // Even the largest monorepos have at most thousands of packages.
+        let total = results.len() as u32;
+        let succeeded = results.iter().filter(|r| r.success).count() as u32;
+        let failed = total - succeeded;
+        let total_duration_ms: f64 = results.iter().map(|r| r.duration_ms).sum();
+
+        Self::new(total, succeeded, failed, total_duration_ms)
+    }
+
+    /// Checks if all executions succeeded.
+    ///
+    /// # Returns
+    ///
+    /// `true` if `failed` is 0 and `total` > 0.
+    #[must_use]
+    pub fn all_succeeded(&self) -> bool {
+        self.total > 0 && self.failed == 0
+    }
+
+    /// Checks if any execution failed.
+    ///
+    /// # Returns
+    ///
+    /// `true` if `failed` > 0.
+    #[must_use]
+    pub fn has_failures(&self) -> bool {
+        self.failed > 0
+    }
+}
+
+/// Execute command response data.
+///
+/// This is the main response structure returned by the execute command,
+/// containing the executed command, results for each package, and
+/// aggregate summary statistics.
+///
+/// # Fields
+///
+/// - `command`: The command that was executed
+/// - `results`: Results for each package
+/// - `summary`: Aggregate execution summary
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface ExecuteData {
+///   command: string;
+///   results: PackageExecutionResult[];
+///   summary: ExecuteSummary;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// const data: ExecuteData = {
+///   command: 'npm:test',
+///   results: [
+///     { package: '@scope/core', success: true, exitCode: 0, durationMs: 1500 },
+///     { package: '@scope/utils', success: true, exitCode: 0, durationMs: 800 }
+///   ],
+///   summary: {
+///     total: 2,
+///     succeeded: 2,
+///     failed: 0,
+///     totalDurationMs: 2300
+///   }
+/// };
+///
+/// // Process results
+/// for (const result of data.results) {
+///   console.log(`${result.package}: ${result.success ? 'PASS' : 'FAIL'}`);
+/// }
+/// ```
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecuteData {
+    /// Command that was executed.
+    ///
+    /// The original command string that was passed to execute.
+    /// For npm scripts, this is the `npm:<script>` format.
+    pub command: String,
+
+    /// Results for each package.
+    ///
+    /// Contains execution results for each package that was targeted.
+    /// The order may vary for parallel execution.
+    pub results: Vec<PackageExecutionResult>,
+
+    /// Execution summary.
+    ///
+    /// Aggregate statistics about the execution across all packages.
+    pub summary: ExecuteSummary,
+}
+
+#[allow(dead_code)]
+impl ExecuteData {
+    /// Creates a new `ExecuteData`.
+    ///
+    /// # Arguments
+    ///
+    /// * `command` - The command that was executed
+    /// * `results` - Results for each package
+    /// * `summary` - Execution summary
+    ///
+    /// # Returns
+    ///
+    /// A new `ExecuteData` instance.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::execute::{ExecuteData, ExecuteSummary};
+    ///
+    /// let results = vec![];
+    /// let summary = ExecuteSummary::empty();
+    /// let data = ExecuteData::new("npm:test", results, summary);
+    /// assert_eq!(data.command, "npm:test");
+    /// ```
+    #[must_use]
+    pub fn new(
+        command: impl Into<String>,
+        results: Vec<PackageExecutionResult>,
+        summary: ExecuteSummary,
+    ) -> Self {
+        Self { command: command.into(), results, summary }
+    }
+
+    /// Creates a new `ExecuteData` with automatically computed summary.
+    ///
+    /// # Arguments
+    ///
+    /// * `command` - The command that was executed
+    /// * `results` - Results for each package
+    ///
+    /// # Returns
+    ///
+    /// A new `ExecuteData` with summary computed from results.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let results = vec![
+    ///     PackageExecutionResult::success("pkg1", 1000),
+    /// ];
+    /// let data = ExecuteData::from_results("npm:test", results);
+    /// assert_eq!(data.summary.total, 1);
+    /// ```
+    #[must_use]
+    pub fn from_results(command: impl Into<String>, results: Vec<PackageExecutionResult>) -> Self {
+        let summary = ExecuteSummary::from_results(&results);
+        Self::new(command, results, summary)
+    }
+
+    /// Creates an empty `ExecuteData`.
+    ///
+    /// # Arguments
+    ///
+    /// * `command` - The command that was executed
+    ///
+    /// # Returns
+    ///
+    /// A new `ExecuteData` with no results.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let data = ExecuteData::empty("npm:test");
+    /// assert!(data.results.is_empty());
+    /// assert_eq!(data.summary.total, 0);
+    /// ```
+    #[must_use]
+    pub fn empty(command: impl Into<String>) -> Self {
+        Self::new(command, vec![], ExecuteSummary::empty())
+    }
+
+    /// Returns the number of packages processed.
+    ///
+    /// # Returns
+    ///
+    /// The count of results.
+    #[must_use]
+    pub fn package_count(&self) -> usize {
+        self.results.len()
+    }
+
+    /// Checks if all executions succeeded.
+    ///
+    /// # Returns
+    ///
+    /// `true` if all packages succeeded.
+    #[must_use]
+    pub fn all_succeeded(&self) -> bool {
+        self.summary.all_succeeded()
+    }
+
+    /// Checks if any execution failed.
+    ///
+    /// # Returns
+    ///
+    /// `true` if any package failed.
+    #[must_use]
+    pub fn has_failures(&self) -> bool {
+        self.summary.has_failures()
+    }
+}
+
+// ============================================================================
+// API Response Type
+// ============================================================================
+
+/// API response for the execute command.
+///
+/// This is a concrete (non-generic) response type specifically for the execute
+/// command. It uses `#[napi(object)]` to enable automatic conversion to
+/// JavaScript objects.
+///
+/// napi-rs cannot use generic types with `#[napi(object)]`, so each command
+/// that returns structured data needs its own concrete response type.
+///
+/// # Fields
+///
+/// - `success`: Whether the operation succeeded
+/// - `data`: The execute data (present when success is true)
+/// - `error`: Error information (present when success is false)
+///
+/// # TypeScript Definition
+///
+/// ```typescript
+/// interface ExecuteApiResponse {
+///   success: boolean;
+///   data?: ExecuteData;
+///   error?: ErrorInfo;
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```typescript
+/// const result = await execute({ root: '.', cmd: 'npm:test' });
+///
+/// if (result.success) {
+///   // result.data is ExecuteData
+///   console.log(`${result.data.summary.succeeded}/${result.data.summary.total} succeeded`);
+///   for (const pkg of result.data.results) {
+///     const icon = pkg.success ? '✓' : '✗';
+///     console.log(`${icon} ${pkg.package}`);
+///   }
+/// } else {
+///   // result.error is ErrorInfo
+///   console.error(`[${result.error.code}] ${result.error.message}`);
+/// }
+/// ```
+// TODO: will be used on story 6.3 (execute command)
+#[allow(dead_code)]
+#[napi(object)]
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecuteApiResponse {
+    /// Whether the operation succeeded.
+    ///
+    /// - `true`: Command execution completed, `data` field will be present
+    /// - `false`: Operation failed, `error` field will be present
+    ///
+    /// Note: This indicates whether the execute operation itself succeeded,
+    /// not whether all package commands succeeded. Check `data.summary.failed`
+    /// to determine if any package commands failed.
+    pub success: bool,
+
+    /// The execute data (only present when `success` is `true`).
+    ///
+    /// Contains execution results for each package and aggregate summary.
+    #[napi(ts_type = "ExecuteData | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<ExecuteData>,
+
+    /// Error information (only present when `success` is `false`).
+    ///
+    /// Contains structured error information with a Node.js-style error code,
+    /// message, optional context, and error kind.
+    #[napi(ts_type = "ErrorInfo | undefined")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorInfo>,
+}
+
+#[allow(dead_code)]
+impl ExecuteApiResponse {
+    /// Creates a successful execute response with data.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - The execute data to include
+    ///
+    /// # Returns
+    ///
+    /// A new `ExecuteApiResponse` with `success = true` and the provided data.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::execute::{ExecuteApiResponse, ExecuteData};
+    ///
+    /// let data = ExecuteData::empty("npm:test");
+    /// let response = ExecuteApiResponse::success(data);
+    /// assert!(response.success);
+    /// assert!(response.data.is_some());
+    /// ```
+    #[must_use]
+    pub fn success(data: ExecuteData) -> Self {
+        Self { success: true, data: Some(data), error: None }
+    }
+
+    /// Creates a failed execute response with error information.
+    ///
+    /// # Arguments
+    ///
+    /// * `error` - The error information to include
+    ///
+    /// # Returns
+    ///
+    /// A new `ExecuteApiResponse` with `success = false` and the provided error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_node_tools::types::execute::ExecuteApiResponse;
+    /// use sublime_node_tools::error::ErrorInfo;
+    ///
+    /// let error = ErrorInfo::validation("Invalid root path", Some("root"));
+    /// let response = ExecuteApiResponse::failure(error);
+    /// assert!(!response.success);
+    /// assert!(response.error.is_some());
+    /// ```
+    #[must_use]
+    pub fn failure(error: ErrorInfo) -> Self {
+        Self { success: false, data: None, error: Some(error) }
+    }
+
+    /// Returns whether this response represents a success.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the operation succeeded, `false` otherwise.
+    #[must_use]
+    pub fn is_success(&self) -> bool {
+        self.success
+    }
+
+    /// Returns whether this response represents a failure.
+    ///
+    /// # Returns
+    ///
+    /// `true` if the operation failed, `false` otherwise.
+    #[must_use]
+    pub fn is_failure(&self) -> bool {
+        !self.success
+    }
+}

--- a/crates/node/src/types/mod.rs
+++ b/crates/node/src/types/mod.rs
@@ -161,8 +161,23 @@ pub(crate) mod changes;
 // TODO: will be implemented on story 9.3 (clone types)
 pub(crate) mod clone;
 
-// TODO: will be implemented on story 6.2 (execute types)
+// Execute types (Story 6.2 - Implemented)
 pub(crate) mod execute;
+
+// Re-export execute types for easier access
+// Allow unused imports - these will be used by the execute command (Story 6.3)
+#[allow(unused_imports)]
+pub(crate) use execute::{
+    // API Response
+    ExecuteApiResponse,
+    // Response Data
+    ExecuteData,
+    // Input Parameters
+    ExecuteParams,
+    // Supporting Types
+    ExecuteSummary,
+    PackageExecutionResult,
+};
 
 // Common types used across multiple commands
 pub(crate) mod common;

--- a/packages/workspace-tools/npm/darwin-arm64/package.json
+++ b/packages/workspace-tools/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-arm64",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/darwin-x64/package.json
+++ b/packages/workspace-tools/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-x64",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-gnu",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-musl",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-gnu",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-musl",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/win32-arm64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-arm64-msvc",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/win32-x64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-x64-msvc",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "Bindings for node from crate workspace-tools",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/types/index.d.cts",

--- a/packages/workspace-tools/src/binding.d.ts
+++ b/packages/workspace-tools/src/binding.d.ts
@@ -3102,6 +3102,407 @@ export interface ErrorInfo {
 }
 
 /**
+ * API response for the execute command.
+ *
+ * This is a concrete (non-generic) response type specifically for the execute
+ * command. It uses `#[napi(object)]` to enable automatic conversion to
+ * JavaScript objects.
+ *
+ * napi-rs cannot use generic types with `#[napi(object)]`, so each command
+ * that returns structured data needs its own concrete response type.
+ *
+ * # Fields
+ *
+ * - `success`: Whether the operation succeeded
+ * - `data`: The execute data (present when success is true)
+ * - `error`: Error information (present when success is false)
+ *
+ * # TypeScript Definition
+ *
+ * ```typescript
+ * interface ExecuteApiResponse {
+ *   success: boolean;
+ *   data?: ExecuteData;
+ *   error?: ErrorInfo;
+ * }
+ * ```
+ *
+ * # Examples
+ *
+ * ```typescript
+ * const result = await execute({ root: '.', cmd: 'npm:test' });
+ *
+ * if (result.success) {
+ *   // result.data is ExecuteData
+ *   console.log(`${result.data.summary.succeeded}/${result.data.summary.total} succeeded`);
+ *   for (const pkg of result.data.results) {
+ *     const icon = pkg.success ? '✓' : '✗';
+ *     console.log(`${icon} ${pkg.package}`);
+ *   }
+ * } else {
+ *   // result.error is ErrorInfo
+ *   console.error(`[${result.error.code}] ${result.error.message}`);
+ * }
+ * ```
+ */
+export interface ExecuteApiResponse {
+  /**
+   * Whether the operation succeeded.
+   *
+   * - `true`: Command execution completed, `data` field will be present
+   * - `false`: Operation failed, `error` field will be present
+   *
+   * Note: This indicates whether the execute operation itself succeeded,
+   * not whether all package commands succeeded. Check `data.summary.failed`
+   * to determine if any package commands failed.
+   */
+  success: boolean
+  /**
+   * The execute data (only present when `success` is `true`).
+   *
+   * Contains execution results for each package and aggregate summary.
+   */
+  data?: ExecuteData | undefined
+  /**
+   * Error information (only present when `success` is `false`).
+   *
+   * Contains structured error information with a Node.js-style error code,
+   * message, optional context, and error kind.
+   */
+  error?: ErrorInfo | undefined
+}
+
+/**
+ * Execute command response data.
+ *
+ * This is the main response structure returned by the execute command,
+ * containing the executed command, results for each package, and
+ * aggregate summary statistics.
+ *
+ * # Fields
+ *
+ * - `command`: The command that was executed
+ * - `results`: Results for each package
+ * - `summary`: Aggregate execution summary
+ *
+ * # TypeScript Definition
+ *
+ * ```typescript
+ * interface ExecuteData {
+ *   command: string;
+ *   results: PackageExecutionResult[];
+ *   summary: ExecuteSummary;
+ * }
+ * ```
+ *
+ * # Examples
+ *
+ * ```typescript
+ * const data: ExecuteData = {
+ *   command: 'npm:test',
+ *   results: [
+ *     { package: '@scope/core', success: true, exitCode: 0, durationMs: 1500 },
+ *     { package: '@scope/utils', success: true, exitCode: 0, durationMs: 800 }
+ *   ],
+ *   summary: {
+ *     total: 2,
+ *     succeeded: 2,
+ *     failed: 0,
+ *     totalDurationMs: 2300
+ *   }
+ * };
+ *
+ * // Process results
+ * for (const result of data.results) {
+ *   console.log(`${result.package}: ${result.success ? 'PASS' : 'FAIL'}`);
+ * }
+ * ```
+ */
+export interface ExecuteData {
+  /**
+   * Command that was executed.
+   *
+   * The original command string that was passed to execute.
+   * For npm scripts, this is the `npm:<script>` format.
+   */
+  command: string
+  /**
+   * Results for each package.
+   *
+   * Contains execution results for each package that was targeted.
+   * The order may vary for parallel execution.
+   */
+  results: Array<PackageExecutionResult>
+  /**
+   * Execution summary.
+   *
+   * Aggregate statistics about the execution across all packages.
+   */
+  summary: ExecuteSummary
+}
+
+/**
+ * Input parameters for the execute command.
+ *
+ * This structure defines the parameters for running commands across workspace
+ * packages. It supports filtering by package names or affected packages,
+ * parallel execution, and configurable timeouts.
+ *
+ * # Fields
+ *
+ * - `root`: The workspace root directory path (required)
+ * - `cmd`: The command to execute (required)
+ * - `filter_package`: Filter by specific package names
+ * - `affected`: Execute only on affected packages
+ * - `since`: Git reference for affected detection start
+ * - `until`: Git reference for affected detection end
+ * - `branch`: Base branch for affected comparison
+ * - `parallel`: Run commands in parallel
+ * - `args`: Additional arguments to pass to the command
+ * - `timeout_secs`: Global timeout in seconds
+ * - `per_package_timeout_secs`: Per-package timeout in seconds
+ *
+ * # Mutual Exclusion
+ *
+ * `filter_package` and `affected` are mutually exclusive. Only one can be
+ * specified at a time. Validation should ensure this constraint is enforced.
+ *
+ * # TypeScript Definition
+ *
+ * ```typescript
+ * interface ExecuteParams {
+ *   root: string;
+ *   cmd: string;
+ *   filterPackage?: string[];
+ *   affected?: boolean;
+ *   since?: string;
+ *   until?: string;
+ *   branch?: string;
+ *   parallel?: boolean;
+ *   args?: string[];
+ *   timeoutSecs?: number;
+ *   perPackageTimeoutSecs?: number;
+ * }
+ * ```
+ *
+ * # Examples
+ *
+ * ```typescript
+ * // Run tests on affected packages
+ * const params: ExecuteParams = {
+ *   root: '.',
+ *   cmd: 'npm:test',
+ *   affected: true,
+ *   branch: 'main',
+ *   parallel: true
+ * };
+ *
+ * // Run build on specific packages with timeout
+ * const buildParams: ExecuteParams = {
+ *   root: '/path/to/workspace',
+ *   cmd: 'npm:build',
+ *   filterPackage: ['@scope/core', '@scope/utils'],
+ *   timeoutSecs: 600,
+ *   perPackageTimeoutSecs: 120
+ * };
+ *
+ * // Run system command with extra arguments
+ * const systemParams: ExecuteParams = {
+ *   root: '.',
+ *   cmd: 'echo',
+ *   args: ['Hello', 'World']
+ * };
+ * ```
+ */
+export interface ExecuteParams {
+  /**
+   * Workspace root directory path.
+   *
+   * This is the absolute or relative path to the root of the workspace.
+   * For monorepos, this should point to the root where the package manager
+   * configuration is located.
+   */
+  root: string
+  /**
+   * Command to execute.
+   *
+   * Supports two formats:
+   * - `npm:<script>`: Runs an npm script (e.g., `npm:lint`, `npm:build`)
+   * - Plain command: Runs a system command (e.g., `ls -la`, `node index.js`)
+   *
+   * For npm scripts, the appropriate package manager (npm, yarn, pnpm, bun)
+   * is automatically detected and used.
+   */
+  cmd: string
+  /**
+   * Filter packages to run command on.
+   *
+   * When provided, only executes the command in the specified packages.
+   * Package names should match exactly (e.g., `@scope/package`).
+   *
+   * Mutually exclusive with `affected`.
+   */
+  filterPackage?: string[] | undefined
+  /**
+   * Execute only on packages affected by changes.
+   *
+   * When `true`, automatically detects packages with changes and runs
+   * commands only on them. By default, analyzes working directory changes
+   * (staged + unstaged).
+   *
+   * Use `since`/`until` for commit range analysis, or `branch` for
+   * branch comparison.
+   *
+   * Mutually exclusive with `filter_package`.
+   */
+  affected?: boolean | undefined
+  /**
+   * Since commit/branch/tag for affected detection.
+   *
+   * Used with `affected: true` to analyze changes since this Git reference.
+   * If not specified with `affected`, analyzes working directory changes.
+   *
+   * Example: `"HEAD~5"`, `"v1.0.0"`, `"main"`
+   */
+  since?: string | undefined
+  /**
+   * Until commit/branch/tag for affected detection.
+   *
+   * Used with `affected: true` to analyze changes until this Git reference.
+   * Defaults to `HEAD` when `since` is specified.
+   *
+   * Example: `"HEAD"`, `"v2.0.0"`
+   */
+  until?: string | undefined
+  /**
+   * Compare against branch for affected detection.
+   *
+   * Used with `affected: true` to compare current branch against the
+   * target branch. Detects packages changed between current branch and
+   * the specified branch.
+   *
+   * Example: `"main"`, `"develop"`
+   */
+  branch?: string | undefined
+  /**
+   * Run commands in parallel across packages.
+   *
+   * When `true`, all package commands run concurrently. By default,
+   * commands run sequentially.
+   *
+   * Note: Parallel execution may interleave output from different packages.
+   */
+  parallel?: boolean | undefined
+  /**
+   * Additional arguments passed to the command.
+   *
+   * These arguments are appended to the command after the base command
+   * and any npm script arguments.
+   *
+   * Example: `["--coverage", "--verbose"]`
+   */
+  args?: string[] | undefined
+  /**
+   * Timeout for the entire execute operation in seconds.
+   *
+   * This is the global timeout for executing commands across all packages.
+   * A value of `0` is invalid; use `None` to indicate no timeout.
+   *
+   * If not provided, the default from the configuration is used (typically
+   * 300 seconds / 5 minutes).
+   *
+   * Note: This parameter overrides the configuration value when provided.
+   */
+  timeoutSecs?: number | undefined
+  /**
+   * Timeout per package execution in seconds.
+   *
+   * This is the timeout for executing the command in a single package.
+   * A value of `0` is invalid; use `None` to indicate no per-package timeout.
+   *
+   * If not provided, the default from the configuration is used (typically
+   * 60 seconds / 1 minute).
+   *
+   * Note: This parameter overrides the configuration value when provided.
+   */
+  perPackageTimeoutSecs?: number | undefined
+}
+
+/**
+ * Execution summary for all packages.
+ *
+ * Provides aggregate statistics about command execution across all
+ * targeted packages, including counts and total duration.
+ *
+ * # Fields
+ *
+ * - `total`: Total number of packages
+ * - `succeeded`: Number of successful executions
+ * - `failed`: Number of failed executions
+ * - `total_duration_ms`: Total execution duration in milliseconds
+ *
+ * # TypeScript Definition
+ *
+ * ```typescript
+ * interface ExecuteSummary {
+ *   total: number;
+ *   succeeded: number;
+ *   failed: number;
+ *   totalDurationMs: number;
+ * }
+ * ```
+ *
+ * # Examples
+ *
+ * ```typescript
+ * const summary: ExecuteSummary = {
+ *   total: 5,
+ *   succeeded: 4,
+ *   failed: 1,
+ *   totalDurationMs: 15000
+ * };
+ *
+ * // Check if all succeeded
+ * if (summary.succeeded === summary.total) {
+ *   console.log('All packages passed!');
+ * }
+ * ```
+ */
+export interface ExecuteSummary {
+  /**
+   * Total number of packages processed.
+   *
+   * This is the count of all packages that were targeted for execution,
+   * regardless of success or failure.
+   */
+  total: number
+  /**
+   * Number of successful executions.
+   *
+   * Count of packages where the command exited with code 0.
+   */
+  succeeded: number
+  /**
+   * Number of failed executions.
+   *
+   * Count of packages where the command exited with non-zero code
+   * or encountered an error.
+   */
+  failed: number
+  /**
+   * Total execution duration in milliseconds.
+   *
+   * For sequential execution, this is the sum of all package durations.
+   * For parallel execution, this is the wall-clock time from start to finish.
+   *
+   * Note: Uses `f64` for JavaScript compatibility. JavaScript numbers are
+   * internally f64, which can represent integers up to 2^53 without precision
+   * loss, more than sufficient for duration values.
+   */
+  totalDurationMs: number
+}
+
+/**
  * Returns the version of the crate.
  *
  * This function is exposed to Node.js and returns the current version
@@ -3539,6 +3940,96 @@ export interface InitParams {
    * ```
    */
   force?: boolean | undefined
+}
+
+/**
+ * Result for a single package execution.
+ *
+ * Contains the outcome of executing a command in one package, including
+ * success status, exit code, duration, and any error message.
+ *
+ * # Fields
+ *
+ * - `package`: The package name
+ * - `success`: Whether execution succeeded
+ * - `exit_code`: Exit code from the command
+ * - `duration_ms`: Execution duration in milliseconds
+ * - `error`: Error message if execution failed
+ *
+ * # TypeScript Definition
+ *
+ * ```typescript
+ * interface PackageExecutionResult {
+ *   package: string;
+ *   success: boolean;
+ *   exitCode: number;
+ *   durationMs: number;
+ *   error?: string;
+ * }
+ * ```
+ *
+ * # Examples
+ *
+ * ```typescript
+ * // Successful execution
+ * const success: PackageExecutionResult = {
+ *   package: '@scope/core',
+ *   success: true,
+ *   exitCode: 0,
+ *   durationMs: 1500
+ * };
+ *
+ * // Failed execution
+ * const failed: PackageExecutionResult = {
+ *   package: '@scope/utils',
+ *   success: false,
+ *   exitCode: 1,
+ *   durationMs: 500,
+ *   error: 'Test suite failed with 3 failing tests'
+ * };
+ * ```
+ */
+export interface PackageExecutionResult {
+  /**
+   * Package name.
+   *
+   * The name of the package where the command was executed.
+   * This matches the name in the package's `package.json`.
+   */
+  package: string
+  /**
+   * Whether execution succeeded.
+   *
+   * - `true`: Command exited with code 0
+   * - `false`: Command exited with non-zero code or errored
+   */
+  success: boolean
+  /**
+   * Exit code from the command.
+   *
+   * The process exit code returned by the command.
+   * Typically `0` for success, non-zero for failure.
+   * May be `-1` if the process was terminated or couldn't be started.
+   */
+  exitCode: number
+  /**
+   * Execution duration in milliseconds.
+   *
+   * The time taken to execute the command in this package,
+   * measured from start to completion.
+   *
+   * Note: Uses `f64` for JavaScript compatibility. JavaScript numbers are
+   * internally f64, which can represent integers up to 2^53 without precision
+   * loss, more than sufficient for duration values.
+   */
+  durationMs: number
+  /**
+   * Error message if execution failed.
+   *
+   * Contains error details when `success` is `false`.
+   * May include stderr output or error descriptions.
+   */
+  error?: string | undefined
 }
 
 /**

--- a/packages/workspace-tools/src/binding.js
+++ b/packages/workspace-tools/src/binding.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm-eabi')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-ia32-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-arm64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@websublime/workspace-tools-darwin-universal')
       const bindingPackageVersion = require('@websublime/workspace-tools-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-musleabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-ppc64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-s390x-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.0.14' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.14 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.15' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.15 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {

--- a/packages/workspace-tools/src/index.ts
+++ b/packages/workspace-tools/src/index.ts
@@ -27,6 +27,10 @@
  * - `BumpSnapshotParams`, `BumpSnapshotData`, `BumpSnapshotApiResponse`
  * - `PackageVersionInfo`, `SnapshotVersionInfo`, `DependencyUpdateInfo`, `BumpSummaryInfo`
  *
+ * Execute types (Story 6.2):
+ * - `ExecuteParams`, `ExecuteData`, `ExecuteApiResponse`
+ * - `PackageExecutionResult`, `ExecuteSummary`
+ *
  * ## How
  *
  * The native bindings are compiled from Rust using napi-rs and exposed through
@@ -45,9 +49,37 @@
  */
 
 // Re-export all functions from bindings
-import { bumpApply, bumpPreview, bumpSnapshot, changesetAdd, changesetCheck, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status } from './binding'
+import {
+  bumpApply,
+  bumpPreview,
+  bumpSnapshot,
+  changesetAdd,
+  changesetCheck,
+  changesetHistory,
+  changesetList,
+  changesetRemove,
+  changesetShow,
+  changesetUpdate,
+  getVersion,
+  init,
+  status,
+} from './binding'
 
-export { bumpApply, bumpPreview, bumpSnapshot, changesetAdd, changesetCheck, changesetHistory, changesetList, changesetRemove, changesetShow, changesetUpdate, getVersion, init, status }
+export {
+  bumpApply,
+  bumpPreview,
+  bumpSnapshot,
+  changesetAdd,
+  changesetCheck,
+  changesetHistory,
+  changesetList,
+  changesetRemove,
+  changesetShow,
+  changesetUpdate,
+  getVersion,
+  init,
+  status,
+}
 
 // Re-export all types from bindings
 export type {
@@ -128,4 +160,18 @@ export type {
   SnapshotVersionInfo,
   DependencyUpdateInfo,
   BumpSummaryInfo,
+
+  // Execute command types (Story 6.2)
+  // Input parameters
+  ExecuteParams,
+
+  // Response data
+  ExecuteData,
+
+  // API response
+  ExecuteApiResponse,
+
+  // Supporting types
+  PackageExecutionResult,
+  ExecuteSummary,
 } from './binding'


### PR DESCRIPTION
- Add ExecuteParams with timeout and filtering options
- Add PackageExecutionResult for per-package execution results
- Add ExecuteSummary for aggregate execution statistics
- Add ExecuteData as main response structure
- Add ExecuteApiResponse for NAPI-compatible responses
- Update types/mod.rs with execute type re-exports
- Add 41 comprehensive tests for all execute types
- Update dependency versions (cli: 0.0.31, pkg: 0.0.22)
- Regenerate NAPI bindings with new execute types
- Export execute types from packages/workspace-tools/src/index.ts

Story 6.2: Implement Execute Types