### PR TITLE
feat(WOR-TSK-207): implement upgradeCheck NAPI function for Story 8.2

### DIFF
--- a/crates/node/src/commands/mod.rs
+++ b/crates/node/src/commands/mod.rs
@@ -105,8 +105,14 @@ pub use bump::bump_apply;
 // Story 5.4: bumpSnapshot
 pub use bump::bump_snapshot;
 
-// TODO: will be implemented on story 8.2-8.4 (upgrade commands)
+// Upgrade commands - Story 8.2-8.4
 pub(crate) mod upgrade;
+
+// Re-export upgrade functions for lib.rs
+// Story 8.2: upgradeCheck
+pub use upgrade::upgrade_check;
+// TODO: Story 8.3: upgradeApply
+// TODO: Story 8.4: backupList, backupRestore, backupClean
 
 // TODO: will be implemented on story 9.1 (audit command)
 pub(crate) mod audit;

--- a/crates/node/src/commands/tests.rs
+++ b/crates/node/src/commands/tests.rs
@@ -8022,3 +8022,636 @@ mod config_validate_tests {
         }
     }
 }
+
+// ============================================================================
+// Upgrade Check Command Tests (Story 8.2)
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod upgrade_check_tests {
+    use std::io::Write;
+
+    use crate::commands::upgrade::{
+        CliDependencyUpgradeInfo, CliPackageUpgradeInfo, CliUpgradeCheckData, CliUpgradeSummary,
+        SharedBuffer, convert_params_to_args, convert_to_napi_upgrade_check,
+        parse_upgrade_check_response, validate_upgrade_check_params,
+    };
+    use crate::types::upgrade::UpgradeCheckParams;
+
+    // -------------------------------------------------------------------------
+    // SharedBuffer Tests
+    // -------------------------------------------------------------------------
+
+    mod shared_buffer_tests {
+        use super::*;
+
+        #[test]
+        fn test_shared_buffer_new() {
+            let buffer = SharedBuffer::new();
+            assert!(buffer.take_bytes().is_empty());
+        }
+
+        #[test]
+        fn test_shared_buffer_write() {
+            let mut buffer = SharedBuffer::new();
+            let bytes_written = buffer.write(b"hello").unwrap();
+            assert_eq!(bytes_written, 5);
+            assert_eq!(buffer.take_bytes(), b"hello");
+        }
+
+        #[test]
+        fn test_shared_buffer_multiple_writes() {
+            let mut buffer = SharedBuffer::new();
+            buffer.write_all(b"hello ").unwrap();
+            buffer.write_all(b"world").unwrap();
+            assert_eq!(buffer.take_bytes(), b"hello world");
+        }
+
+        #[test]
+        fn test_shared_buffer_clone_shares_data() {
+            let mut buffer = SharedBuffer::new();
+            let buffer2 = buffer.clone();
+            buffer.write_all(b"shared data").unwrap();
+            assert_eq!(buffer2.take_bytes(), b"shared data");
+        }
+
+        #[test]
+        fn test_shared_buffer_flush() {
+            let mut buffer = SharedBuffer::new();
+            assert!(buffer.flush().is_ok());
+        }
+
+        #[test]
+        fn test_shared_buffer_take_bytes_preserves_data() {
+            let mut buffer = SharedBuffer::new();
+            buffer.write_all(b"preserved").unwrap();
+            let bytes1 = buffer.take_bytes();
+            let bytes2 = buffer.take_bytes();
+            assert_eq!(bytes1, bytes2);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Parse Response Tests
+    // -------------------------------------------------------------------------
+
+    mod parse_response_tests {
+        use super::*;
+
+        #[test]
+        fn test_parse_upgrade_check_response_success() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "packages": [
+                        {
+                            "name": "@scope/pkg1",
+                            "path": "packages/pkg1",
+                            "upgrades": [
+                                {
+                                    "package": "lodash",
+                                    "currentVersion": "4.17.20",
+                                    "latestVersion": "4.17.21",
+                                    "type": "patch",
+                                    "breaking": false
+                                }
+                            ]
+                        }
+                    ],
+                    "summary": {
+                        "totalPackages": 1,
+                        "packagesWithUpgrades": 1,
+                        "totalUpgrades": 1,
+                        "major": 0,
+                        "minor": 0,
+                        "patch": 1
+                    }
+                }
+            }"#;
+
+            let result = parse_upgrade_check_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            assert_eq!(data.packages.len(), 1);
+            assert_eq!(data.packages[0].package_name, "@scope/pkg1");
+            assert_eq!(data.packages[0].package_path, "packages/pkg1");
+            assert_eq!(data.packages[0].dependencies.len(), 1);
+            assert_eq!(data.packages[0].dependencies[0].name, "lodash");
+            assert_eq!(data.packages[0].dependencies[0].current_version, "4.17.20");
+            assert_eq!(data.packages[0].dependencies[0].latest_version, "4.17.21");
+            assert_eq!(data.packages[0].dependencies[0].upgrade_type, "patch");
+            assert_eq!(data.summary.packages_analyzed, 1);
+            assert_eq!(data.summary.total_upgrades, 1);
+            assert_eq!(data.summary.patch_upgrades, 1);
+        }
+
+        #[test]
+        fn test_parse_upgrade_check_response_empty_upgrades() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "packages": [],
+                    "summary": {
+                        "totalPackages": 5,
+                        "packagesWithUpgrades": 0,
+                        "totalUpgrades": 0,
+                        "major": 0,
+                        "minor": 0,
+                        "patch": 0
+                    }
+                }
+            }"#;
+
+            let result = parse_upgrade_check_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            assert!(data.packages.is_empty());
+            assert_eq!(data.summary.packages_analyzed, 5);
+            assert_eq!(data.summary.total_upgrades, 0);
+        }
+
+        #[test]
+        fn test_parse_upgrade_check_response_multiple_packages() {
+            let json = r#"{
+                "success": true,
+                "data": {
+                    "packages": [
+                        {
+                            "name": "pkg1",
+                            "path": "packages/pkg1",
+                            "upgrades": [
+                                {
+                                    "package": "typescript",
+                                    "currentVersion": "5.0.0",
+                                    "latestVersion": "5.3.3",
+                                    "type": "minor",
+                                    "breaking": false
+                                }
+                            ]
+                        },
+                        {
+                            "name": "pkg2",
+                            "path": "packages/pkg2",
+                            "upgrades": [
+                                {
+                                    "package": "eslint",
+                                    "currentVersion": "8.0.0",
+                                    "latestVersion": "9.0.0",
+                                    "type": "major",
+                                    "breaking": true
+                                }
+                            ]
+                        }
+                    ],
+                    "summary": {
+                        "totalPackages": 2,
+                        "packagesWithUpgrades": 2,
+                        "totalUpgrades": 2,
+                        "major": 1,
+                        "minor": 1,
+                        "patch": 0
+                    }
+                }
+            }"#;
+
+            let result = parse_upgrade_check_response(json.as_bytes());
+            assert!(result.is_ok());
+
+            let data = result.unwrap();
+            assert_eq!(data.packages.len(), 2);
+            assert_eq!(data.summary.major_upgrades, 1);
+            assert_eq!(data.summary.minor_upgrades, 1);
+        }
+
+        #[test]
+        fn test_parse_upgrade_check_response_cli_error() {
+            let json = r#"{"success": false, "error": "Workspace not initialized"}"#;
+
+            let result = parse_upgrade_check_response(json.as_bytes());
+            assert!(result.is_err());
+
+            let error = result.unwrap_err();
+            assert!(error.message.contains("Workspace not initialized"));
+        }
+
+        #[test]
+        fn test_parse_upgrade_check_response_empty() {
+            let result = parse_upgrade_check_response(b"");
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("empty response"));
+        }
+
+        #[test]
+        fn test_parse_upgrade_check_response_whitespace_only() {
+            let result = parse_upgrade_check_response(b"   \n\t  ");
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("empty response"));
+        }
+
+        #[test]
+        fn test_parse_upgrade_check_response_invalid_json() {
+            let result = parse_upgrade_check_response(b"not json");
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("Failed to parse"));
+        }
+
+        #[test]
+        fn test_parse_upgrade_check_response_invalid_utf8() {
+            let invalid_utf8 = vec![0xFF, 0xFE];
+            let result = parse_upgrade_check_response(&invalid_utf8);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("Invalid UTF-8"));
+        }
+
+        #[test]
+        fn test_parse_upgrade_check_response_success_no_data() {
+            let json = r#"{"success": true}"#;
+            let result = parse_upgrade_check_response(json.as_bytes());
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("success but no data"));
+        }
+
+        #[test]
+        fn test_parse_upgrade_check_response_cli_error_no_message() {
+            let json = r#"{"success": false}"#;
+            let result = parse_upgrade_check_response(json.as_bytes());
+            assert!(result.is_err());
+            assert!(result.unwrap_err().message.contains("Unknown CLI error"));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Conversion Tests
+    // -------------------------------------------------------------------------
+
+    mod conversion_tests {
+        use super::*;
+
+        #[test]
+        fn test_convert_to_napi_upgrade_check_full() {
+            let cli_data = CliUpgradeCheckData {
+                packages: vec![CliPackageUpgradeInfo {
+                    name: "@scope/core".to_string(),
+                    path: "packages/core".to_string(),
+                    upgrades: vec![
+                        CliDependencyUpgradeInfo {
+                            package: "lodash".to_string(),
+                            current_version: "4.17.20".to_string(),
+                            latest_version: "4.17.21".to_string(),
+                            upgrade_type: "patch".to_string(),
+                            breaking: false,
+                        },
+                        CliDependencyUpgradeInfo {
+                            package: "typescript".to_string(),
+                            current_version: "5.0.0".to_string(),
+                            latest_version: "5.3.3".to_string(),
+                            upgrade_type: "minor".to_string(),
+                            breaking: false,
+                        },
+                    ],
+                }],
+                summary: CliUpgradeSummary {
+                    total_packages: 3,
+                    packages_with_upgrades: 1,
+                    total_upgrades: 2,
+                    major_upgrades: 0,
+                    minor_upgrades: 1,
+                    patch_upgrades: 1,
+                },
+            };
+
+            let napi_data = convert_to_napi_upgrade_check(cli_data);
+
+            assert_eq!(napi_data.packages.len(), 1);
+            assert_eq!(napi_data.packages[0].package_name, "@scope/core");
+            assert_eq!(napi_data.packages[0].package_path, "packages/core");
+            assert_eq!(napi_data.packages[0].dependencies.len(), 2);
+            assert_eq!(napi_data.packages[0].dependencies[0].name, "lodash");
+            assert_eq!(napi_data.packages[0].dependencies[0].upgrade_type, "patch");
+            assert_eq!(napi_data.packages[0].dependencies[1].name, "typescript");
+            assert_eq!(napi_data.packages[0].dependencies[1].upgrade_type, "minor");
+            assert_eq!(napi_data.summary.packages_analyzed, 3);
+            assert_eq!(napi_data.summary.total_upgrades, 2);
+            assert_eq!(napi_data.summary.major_upgrades, 0);
+            assert_eq!(napi_data.summary.minor_upgrades, 1);
+            assert_eq!(napi_data.summary.patch_upgrades, 1);
+        }
+
+        #[test]
+        fn test_convert_to_napi_upgrade_check_empty() {
+            let cli_data = CliUpgradeCheckData {
+                packages: vec![],
+                summary: CliUpgradeSummary {
+                    total_packages: 5,
+                    packages_with_upgrades: 0,
+                    total_upgrades: 0,
+                    major_upgrades: 0,
+                    minor_upgrades: 0,
+                    patch_upgrades: 0,
+                },
+            };
+
+            let napi_data = convert_to_napi_upgrade_check(cli_data);
+
+            assert!(napi_data.packages.is_empty());
+            assert_eq!(napi_data.summary.packages_analyzed, 5);
+            assert_eq!(napi_data.summary.total_upgrades, 0);
+        }
+
+        #[test]
+        fn test_convert_params_to_args_defaults() {
+            let params = UpgradeCheckParams {
+                root: ".".to_string(),
+                config_path: None,
+                include_major: None,
+                include_minor: None,
+                include_patch: None,
+                include_dev_dependencies: None,
+                include_peer_dependencies: None,
+                packages: None,
+            };
+
+            let args = convert_params_to_args(&params);
+
+            // Default behavior: include all (so no_* is false)
+            assert!(!args.no_major);
+            assert!(!args.no_minor);
+            assert!(!args.no_patch);
+            assert!(!args.no_dev);
+            assert!(!args.peer);
+            assert!(args.packages.is_none());
+            assert!(args.registry.is_none());
+        }
+
+        #[test]
+        fn test_convert_params_to_args_exclude_major() {
+            let params = UpgradeCheckParams {
+                root: ".".to_string(),
+                config_path: None,
+                include_major: Some(false),
+                include_minor: Some(true),
+                include_patch: Some(true),
+                include_dev_dependencies: None,
+                include_peer_dependencies: None,
+                packages: None,
+            };
+
+            let args = convert_params_to_args(&params);
+
+            assert!(args.no_major);
+            assert!(!args.no_minor);
+            assert!(!args.no_patch);
+        }
+
+        #[test]
+        fn test_convert_params_to_args_with_packages() {
+            let params = UpgradeCheckParams {
+                root: ".".to_string(),
+                config_path: None,
+                include_major: None,
+                include_minor: None,
+                include_patch: None,
+                include_dev_dependencies: None,
+                include_peer_dependencies: None,
+                packages: Some(vec!["@scope/pkg1".to_string(), "@scope/pkg2".to_string()]),
+            };
+
+            let args = convert_params_to_args(&params);
+
+            assert!(args.packages.is_some());
+            let packages = args.packages.unwrap();
+            assert_eq!(packages.len(), 2);
+            assert_eq!(packages[0], "@scope/pkg1");
+            assert_eq!(packages[1], "@scope/pkg2");
+        }
+
+        #[test]
+        fn test_convert_params_to_args_include_peer() {
+            let params = UpgradeCheckParams {
+                root: ".".to_string(),
+                config_path: None,
+                include_major: None,
+                include_minor: None,
+                include_patch: None,
+                include_dev_dependencies: None,
+                include_peer_dependencies: Some(true),
+                packages: None,
+            };
+
+            let args = convert_params_to_args(&params);
+
+            assert!(args.peer);
+        }
+
+        #[test]
+        fn test_convert_params_to_args_exclude_dev() {
+            let params = UpgradeCheckParams {
+                root: ".".to_string(),
+                config_path: None,
+                include_major: None,
+                include_minor: None,
+                include_patch: None,
+                include_dev_dependencies: Some(false),
+                include_peer_dependencies: None,
+                packages: None,
+            };
+
+            let args = convert_params_to_args(&params);
+
+            assert!(args.no_dev);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation Tests
+    // -------------------------------------------------------------------------
+
+    mod validation_tests {
+        use super::*;
+
+        #[test]
+        fn test_validate_params_valid_directory() {
+            let params = UpgradeCheckParams {
+                root: ".".to_string(),
+                config_path: None,
+                include_major: None,
+                include_minor: None,
+                include_patch: None,
+                include_dev_dependencies: None,
+                include_peer_dependencies: None,
+                packages: None,
+            };
+
+            let result = validate_upgrade_check_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_params_nonexistent_path() {
+            let params = UpgradeCheckParams {
+                root: "/nonexistent/path/to/workspace".to_string(),
+                config_path: None,
+                include_major: None,
+                include_minor: None,
+                include_patch: None,
+                include_dev_dependencies: None,
+                include_peer_dependencies: None,
+                packages: None,
+            };
+
+            let result = validate_upgrade_check_params(&params);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().code, "ENOENT");
+        }
+
+        #[test]
+        fn test_validate_params_empty_root() {
+            let params = UpgradeCheckParams {
+                root: String::new(),
+                config_path: None,
+                include_major: None,
+                include_minor: None,
+                include_patch: None,
+                include_dev_dependencies: None,
+                include_peer_dependencies: None,
+                packages: None,
+            };
+
+            let result = validate_upgrade_check_params(&params);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err().code, "EVALIDATION");
+        }
+
+        #[test]
+        fn test_validate_params_all_upgrade_types_disabled() {
+            let params = UpgradeCheckParams {
+                root: ".".to_string(),
+                config_path: None,
+                include_major: Some(false),
+                include_minor: Some(false),
+                include_patch: Some(false),
+                include_dev_dependencies: None,
+                include_peer_dependencies: None,
+                packages: None,
+            };
+
+            let result = validate_upgrade_check_params(&params);
+            assert!(result.is_err());
+            let error = result.unwrap_err();
+            assert_eq!(error.code, "EVALIDATION");
+            assert!(error.message.contains("At least one upgrade type"));
+        }
+
+        #[test]
+        fn test_validate_params_one_upgrade_type_enabled() {
+            let params = UpgradeCheckParams {
+                root: ".".to_string(),
+                config_path: None,
+                include_major: Some(false),
+                include_minor: Some(false),
+                include_patch: Some(true),
+                include_dev_dependencies: None,
+                include_peer_dependencies: None,
+                packages: None,
+            };
+
+            let result = validate_upgrade_check_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_params_with_packages() {
+            let params = UpgradeCheckParams {
+                root: ".".to_string(),
+                config_path: None,
+                include_major: None,
+                include_minor: None,
+                include_patch: None,
+                include_dev_dependencies: None,
+                include_peer_dependencies: None,
+                packages: Some(vec!["@scope/pkg1".to_string()]),
+            };
+
+            let result = validate_upgrade_check_params(&params);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_validate_params_returns_correct_path() {
+            let params = UpgradeCheckParams {
+                root: ".".to_string(),
+                config_path: None,
+                include_major: None,
+                include_minor: None,
+                include_patch: None,
+                include_dev_dependencies: None,
+                include_peer_dependencies: None,
+                packages: None,
+            };
+
+            let result = validate_upgrade_check_params(&params);
+            assert!(result.is_ok());
+
+            let path = result.unwrap();
+            assert_eq!(path.to_str().unwrap(), ".");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Params Builder Tests
+    // -------------------------------------------------------------------------
+
+    mod params_builder_tests {
+        use super::*;
+
+        #[test]
+        fn test_upgrade_check_params_new() {
+            let params = UpgradeCheckParams::new(".");
+            assert_eq!(params.root, ".");
+            assert!(params.config_path.is_none());
+            assert!(params.include_major.is_none());
+            assert!(params.include_minor.is_none());
+            assert!(params.include_patch.is_none());
+        }
+
+        #[test]
+        fn test_upgrade_check_params_builder_chain() {
+            let params = UpgradeCheckParams::new(".")
+                .with_include_major(false)
+                .with_include_minor(true)
+                .with_include_patch(true);
+
+            assert_eq!(params.include_major, Some(false));
+            assert_eq!(params.include_minor, Some(true));
+            assert_eq!(params.include_patch, Some(true));
+        }
+
+        #[test]
+        fn test_upgrade_check_params_with_packages() {
+            let packages = vec!["@scope/pkg1".to_string(), "@scope/pkg2".to_string()];
+            let params = UpgradeCheckParams::new(".").with_packages(packages.clone());
+
+            assert_eq!(params.packages, Some(packages));
+        }
+
+        #[test]
+        fn test_upgrade_check_params_with_config_path() {
+            let params =
+                UpgradeCheckParams::new(".").with_config_path("custom.config.json".to_string());
+
+            assert_eq!(params.config_path, Some("custom.config.json".to_string()));
+        }
+
+        #[test]
+        fn test_upgrade_check_params_with_upgrade_levels() {
+            let params = UpgradeCheckParams::new(".").with_upgrade_levels(false, true, true);
+
+            assert_eq!(params.include_major, Some(false));
+            assert_eq!(params.include_minor, Some(true));
+            assert_eq!(params.include_patch, Some(true));
+        }
+    }
+}

--- a/crates/node/src/commands/upgrade.rs
+++ b/crates/node/src/commands/upgrade.rs
@@ -10,17 +10,46 @@
 //!
 //! The module provides the following functions:
 //!
-//! - `upgradeCheck`: Checks for available dependency upgrades
-//! - `upgradeApply`: Applies selected upgrades to package.json files
-//! - `backupCreate`: Creates a backup of current package.json files
-//! - `backupRestore`: Restores package.json files from a backup
-//! - `backupList`: Lists available backups
+//! - `upgrade_check`: Checks for available dependency upgrades
+//! - `upgrade_apply`: Applies selected upgrades to package.json files (TODO: Story 8.3)
+//! - `backup_list`: Lists available backups (TODO: Story 8.4)
+//! - `backup_restore`: Restores package.json files from a backup (TODO: Story 8.4)
+//! - `backup_clean`: Cleans old backups (TODO: Story 8.4)
 //!
 //! Each function:
 //! 1. Validates the input parameters
 //! 2. Calls the appropriate `execute_*` function from `sublime_cli_tools`
 //! 3. Captures the JSON output
-//! 4. Returns a `JsonResponse<T>` with the result
+//! 4. Returns a type-safe API response with the result
+//!
+//! ## Implementation Pattern
+//!
+//! The upgrade commands follow the standard NAPI command pattern:
+//!
+//! ```text
+//! JavaScript Call
+//!        │
+//!        ▼
+//! Parameter Validation (validators::root, etc.)
+//!        │
+//!        ▼
+//! spawn_blocking (for sync file operations)
+//!        │
+//!        ▼
+//! SharedBuffer Output Capture
+//!        │
+//!        ▼
+//! CLI execute_* Function
+//!        │
+//!        ▼
+//! JSON Response Parsing
+//!        │
+//!        ▼
+//! NAPI Type Conversion
+//!        │
+//!        ▼
+//! ApiResponse<Data>
+//! ```
 //!
 //! # Why
 //!
@@ -33,10 +62,10 @@
 //! ```typescript
 //! import {
 //!   upgradeCheck,
-//!   upgradeApply,
-//!   backupCreate,
-//!   backupRestore,
-//!   backupList
+//!   // upgradeApply,     // TODO: Story 8.3
+//!   // backupList,       // TODO: Story 8.4
+//!   // backupRestore,    // TODO: Story 8.4
+//!   // backupClean       // TODO: Story 8.4
 //! } from '@websublime/workspace-tools';
 //!
 //! // Check for available upgrades
@@ -58,115 +87,558 @@
 //!     }
 //!   }
 //! }
-//!
-//! // Create a backup before applying upgrades
-//! const backupResult = await backupCreate({ root: '.' });
-//! const backupId = backupResult.data.backupId;
-//!
-//! // Apply upgrades (minor and patch only)
-//! const applyResult = await upgradeApply({
-//!   root: '.',
-//!   selection: { minor: true, patch: true },
-//!   createChangeset: true
-//! });
-//! if (applyResult.success) {
-//!   console.log(`Applied ${applyResult.data.summary.totalApplied} upgrades`);
-//!   if (applyResult.data.changesetId) {
-//!     console.log(`Created changeset: ${applyResult.data.changesetId}`);
-//!   }
-//! }
-//!
-//! // If something went wrong, restore from backup
-//! if (needsRollback) {
-//!   const restoreResult = await backupRestore({
-//!     root: '.',
-//!     backupId
-//!   });
-//! }
-//!
-//! // List available backups
-//! const listResult = await backupList({ root: '.' });
-//! for (const backup of listResult.data.backups) {
-//!   console.log(`${backup.id}: ${backup.createdAt} (${backup.packages.length} packages)`);
-//! }
 //! ```
 
-// TODO: will be implemented on story 8.2-8.4 - Upgrade Commands
-//
-// Implementation outline for upgradeCheck:
-//
-// #[napi]
-// pub async fn upgrade_check(params: UpgradeCheckParams) -> JsonResponse<UpgradeCheckData> {
-//     // 1. Validate parameters
-//     if let Err(e) = validate_root(&params.root) {
-//         return JsonResponse::from_error_info(e);
-//     }
-//
-//     // 2. Create detection options from params
-//     //    - include_major, include_minor, include_patch
-//     //    - packages filter (optional)
-//     // 3. Create Output with JSON format for capturing
-//     // 4. Call detect_upgrades from sublime_pkg_tools
-//     // 5. Parse and format response with summary
-//     // 6. Return JsonResponse::success(data) or JsonResponse::error(msg)
-// }
-//
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use napi_derive::napi;
+use serde::Deserialize;
+
+use crate::error::ErrorInfo;
+use crate::types::upgrade::{
+    DependencyUpgradeInfo, PackageUpgradeInfo, UpgradeCheckApiResponse, UpgradeCheckData,
+    UpgradeCheckParams, UpgradeSummaryInfo,
+};
+use crate::validation::validators;
+
+use sublime_cli_tools::cli::commands::UpgradeCheckArgs;
+use sublime_cli_tools::commands::upgrade::execute_upgrade_check;
+use sublime_cli_tools::output::{Output, OutputFormat};
+
+// ============================================================================
+// SharedBuffer - Output Capture Mechanism
+// ============================================================================
+
+/// A shared buffer wrapper for capturing CLI output.
+///
+/// The `Output` struct from `sublime_cli_tools` takes ownership of the writer
+/// and doesn't expose an `into_inner()` method. This wrapper uses `Arc<Mutex<Vec<u8>>>`
+/// to allow sharing the buffer between the caller and the Output, enabling
+/// extraction of the written bytes after command execution.
+///
+/// # Thread Safety
+///
+/// The buffer is protected by a `Mutex` to ensure safe concurrent access,
+/// although in typical usage the writes happen sequentially.
+#[derive(Debug, Clone)]
+pub(crate) struct SharedBuffer {
+    /// The inner buffer wrapped in `Arc<Mutex>` for shared ownership.
+    inner: Arc<Mutex<Vec<u8>>>,
+}
+
+impl SharedBuffer {
+    /// Creates a new empty shared buffer.
+    ///
+    /// # Returns
+    ///
+    /// A new `SharedBuffer` instance ready for use with `Output::new()`.
+    pub(crate) fn new() -> Self {
+        Self { inner: Arc::new(Mutex::new(Vec::new())) }
+    }
+
+    /// Extracts the bytes written to the buffer.
+    ///
+    /// This method clones the current buffer contents. The original buffer
+    /// remains intact for potential further writes.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<u8>` containing all bytes written to the buffer.
+    pub(crate) fn take_bytes(&self) -> Vec<u8> {
+        match self.inner.lock() {
+            Ok(guard) => guard.clone(),
+            Err(poisoned) => {
+                // If the mutex is poisoned, still try to get the data
+                // This provides graceful degradation
+                poisoned.into_inner().clone()
+            }
+        }
+    }
+}
+
+impl Write for SharedBuffer {
+    /// Writes data to the shared buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `buf` - The byte slice to write
+    ///
+    /// # Returns
+    ///
+    /// The number of bytes written, or an I/O error if the mutex is poisoned.
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self.inner.lock() {
+            Ok(mut guard) => guard.write(buf),
+            Err(_) => Err(std::io::Error::other("Mutex poisoned")),
+        }
+    }
+
+    /// Flushes the buffer.
+    ///
+    /// Since `Vec<u8>` is an in-memory buffer, this is a no-op.
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+// Required for `Output::new()` which expects `Write + Send`
+// SAFETY: SharedBuffer uses Arc<Mutex<_>> which is Send + Sync
+unsafe impl Send for SharedBuffer {}
+
+// ============================================================================
+// CLI Response Types (for parsing JSON output)
+// ============================================================================
+
+/// CLI JSON response wrapper for upgrade check command.
+///
+/// This type mirrors the `JsonResponse<T>` structure from the CLI crate,
+/// used for deserializing the captured JSON output.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliJsonResponse<T> {
+    /// Whether the operation succeeded.
+    pub(crate) success: bool,
+    /// The response data (present when success is true).
+    pub(crate) data: Option<T>,
+    /// Error message (present when success is false).
+    pub(crate) error: Option<String>,
+}
+
+/// CLI upgrade check response data structure.
+///
+/// Mirrors the `UpgradeCheckResponse` structure from the CLI's upgrade command.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliUpgradeCheckData {
+    /// List of packages with available upgrades.
+    pub(crate) packages: Vec<CliPackageUpgradeInfo>,
+    /// Summary statistics.
+    pub(crate) summary: CliUpgradeSummary,
+}
+
+/// CLI package upgrade information.
+#[derive(Debug, Deserialize)]
+pub(crate) struct CliPackageUpgradeInfo {
+    /// Package name.
+    pub(crate) name: String,
+    /// Package path.
+    pub(crate) path: String,
+    /// List of dependency upgrades.
+    pub(crate) upgrades: Vec<CliDependencyUpgradeInfo>,
+}
+
+/// CLI dependency upgrade information.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliDependencyUpgradeInfo {
+    /// Dependency package name.
+    pub(crate) package: String,
+    /// Current version.
+    pub(crate) current_version: String,
+    /// Latest available version.
+    pub(crate) latest_version: String,
+    /// Upgrade type (major, minor, patch).
+    #[serde(rename = "type")]
+    pub(crate) upgrade_type: String,
+    /// Whether this is a breaking change.
+    #[allow(dead_code)]
+    pub(crate) breaking: bool,
+}
+
+/// CLI upgrade summary.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CliUpgradeSummary {
+    /// Total packages analyzed.
+    pub(crate) total_packages: u32,
+    /// Packages with upgrades.
+    #[allow(dead_code)]
+    pub(crate) packages_with_upgrades: u32,
+    /// Total upgrades available.
+    pub(crate) total_upgrades: u32,
+    /// Major upgrades count.
+    #[serde(rename = "major")]
+    pub(crate) major_upgrades: u32,
+    /// Minor upgrades count.
+    #[serde(rename = "minor")]
+    pub(crate) minor_upgrades: u32,
+    /// Patch upgrades count.
+    #[serde(rename = "patch")]
+    pub(crate) patch_upgrades: u32,
+}
+
+// ============================================================================
+// Conversion Functions
+// ============================================================================
+
+/// Converts CLI upgrade check data to NAPI-compatible `UpgradeCheckData`.
+///
+/// This function performs a field-by-field conversion from the CLI's internal
+/// types to the NAPI types exposed to JavaScript.
+///
+/// # Arguments
+///
+/// * `cli_data` - The parsed CLI response data
+///
+/// # Returns
+///
+/// An `UpgradeCheckData` instance suitable for returning to JavaScript.
+pub(crate) fn convert_to_napi_upgrade_check(cli_data: CliUpgradeCheckData) -> UpgradeCheckData {
+    let packages: Vec<PackageUpgradeInfo> = cli_data
+        .packages
+        .into_iter()
+        .map(|pkg| PackageUpgradeInfo {
+            package_name: pkg.name,
+            package_path: pkg.path,
+            dependencies: pkg
+                .upgrades
+                .into_iter()
+                .map(|dep| DependencyUpgradeInfo {
+                    name: dep.package,
+                    current_version: dep.current_version,
+                    latest_version: dep.latest_version,
+                    upgrade_type: dep.upgrade_type,
+                    // Determine dependency type from the upgrade type (CLI doesn't provide this)
+                    // Default to "regular" since the CLI doesn't distinguish in the check response
+                    dependency_type: "regular".to_string(),
+                })
+                .collect(),
+        })
+        .collect();
+
+    let summary = UpgradeSummaryInfo {
+        packages_analyzed: cli_data.summary.total_packages,
+        total_upgrades: cli_data.summary.total_upgrades,
+        major_upgrades: cli_data.summary.major_upgrades,
+        minor_upgrades: cli_data.summary.minor_upgrades,
+        patch_upgrades: cli_data.summary.patch_upgrades,
+    };
+
+    UpgradeCheckData { packages, summary }
+}
+
+/// Parses the JSON response from the CLI and converts it to NAPI types.
+///
+/// # Arguments
+///
+/// * `json_bytes` - The raw JSON bytes captured from CLI output
+///
+/// # Returns
+///
+/// * `Ok(UpgradeCheckData)` - Successfully parsed and converted upgrade check data
+/// * `Err(ErrorInfo)` - Parsing failed or CLI returned an error
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The JSON is malformed or cannot be parsed
+/// - The CLI returned `success: false` with an error message
+/// - The CLI returned `success: true` but `data` is missing
+pub(crate) fn parse_upgrade_check_response(
+    json_bytes: &[u8],
+) -> Result<UpgradeCheckData, ErrorInfo> {
+    // Convert bytes to string first for better error messages
+    let json_str = std::str::from_utf8(json_bytes)
+        .map_err(|e| ErrorInfo::execution(format!("Invalid UTF-8 in CLI response: {e}")))?;
+
+    // Handle empty response
+    if json_str.trim().is_empty() {
+        return Err(ErrorInfo::execution("CLI returned empty response"));
+    }
+
+    // Parse the JSON response
+    let response: CliJsonResponse<CliUpgradeCheckData> =
+        serde_json::from_str(json_str).map_err(|e| {
+            ErrorInfo::execution(format!(
+                "Failed to parse CLI JSON response: {e} (length={})",
+                json_str.len()
+            ))
+        })?;
+
+    // Check for CLI-level errors
+    if !response.success {
+        let error_message = response.error.unwrap_or_else(|| "Unknown CLI error".to_string());
+        return Err(ErrorInfo::execution(error_message));
+    }
+
+    // Extract and convert data
+    let cli_data =
+        response.data.ok_or_else(|| ErrorInfo::execution("CLI returned success but no data"))?;
+
+    Ok(convert_to_napi_upgrade_check(cli_data))
+}
+
+// ============================================================================
+// Parameter Validation
+// ============================================================================
+
+/// Validates upgrade check command parameters.
+///
+/// Ensures the root path is valid and all filter options are consistent.
+///
+/// # Arguments
+///
+/// * `params` - The upgrade check parameters to validate
+///
+/// # Returns
+///
+/// * `Ok(PathBuf)` - The validated root path
+/// * `Err(ErrorInfo)` - Validation failed
+pub(crate) fn validate_upgrade_check_params(
+    params: &UpgradeCheckParams,
+) -> Result<PathBuf, ErrorInfo> {
+    // Validate root path exists and is a directory
+    validators::root(&params.root)?;
+
+    // Validate that at least one upgrade type is enabled
+    // Default behavior: if no explicit include_* flags are set, include all types
+    let include_major = params.include_major.unwrap_or(true);
+    let include_minor = params.include_minor.unwrap_or(true);
+    let include_patch = params.include_patch.unwrap_or(true);
+
+    if !include_major && !include_minor && !include_patch {
+        return Err(ErrorInfo::validation(
+            "At least one upgrade type (major, minor, or patch) must be enabled",
+            Some("include_major, include_minor, include_patch"),
+        ));
+    }
+
+    Ok(PathBuf::from(&params.root))
+}
+
+/// Converts NAPI params to CLI args.
+///
+/// The CLI uses `no_*` flags (negative logic) while the NAPI API uses
+/// `include_*` flags (positive logic). This function performs the conversion.
+///
+/// # Arguments
+///
+/// * `params` - The NAPI parameters
+///
+/// # Returns
+///
+/// CLI-compatible `UpgradeCheckArgs`.
+pub(crate) fn convert_params_to_args(params: &UpgradeCheckParams) -> UpgradeCheckArgs {
+    // Convert positive include_* flags to negative no_* flags
+    // Default behavior: include all types (so no_* is false by default)
+    let no_major = !params.include_major.unwrap_or(true);
+    let no_minor = !params.include_minor.unwrap_or(true);
+    let no_patch = !params.include_patch.unwrap_or(true);
+
+    // Dev dependencies: default is to include them
+    let no_dev = !params.include_dev_dependencies.unwrap_or(true);
+
+    // Peer dependencies: default is to exclude them
+    let peer = params.include_peer_dependencies.unwrap_or(false);
+
+    UpgradeCheckArgs {
+        no_major,
+        no_minor,
+        no_patch,
+        no_dev,
+        peer,
+        packages: params.packages.clone(),
+        registry: None, // Registry override not exposed in NAPI API
+    }
+}
+
+// ============================================================================
+// NAPI Function - upgradeCheck
+// ============================================================================
+
+/// Check for available dependency upgrades.
+///
+/// Detects which dependencies in the workspace have newer versions available
+/// from the npm registry. This is a read-only operation that does not modify
+/// any files.
+///
+/// The function checks all packages in the workspace and returns a comprehensive
+/// list of available upgrades along with summary statistics.
+///
+/// @param params - Upgrade check parameters containing:
+///   - `root`: Workspace root directory path (required)
+///   - `configPath`: Optional custom configuration file path
+///   - `includeMajor`: Whether to include major version upgrades (default: true)
+///   - `includeMinor`: Whether to include minor version upgrades (default: true)
+///   - `includePatch`: Whether to include patch version upgrades (default: true)
+///   - `includeDevDependencies`: Whether to check devDependencies (default: true)
+///   - `includePeerDependencies`: Whether to check peerDependencies (default: false)
+///   - `packages`: Optional list of packages to check (checks all if not specified)
+///
+/// @returns `Promise<UpgradeCheckApiResponse>` containing:
+///   - On success: `{ success: true, data: UpgradeCheckData }`
+///   - On failure: `{ success: false, error: ErrorInfo }`
+///
+/// @example Basic usage
+/// ```typescript
+/// const result = await upgradeCheck({ root: '.' });
+/// if (result.success) {
+///   console.log(`Found ${result.data.summary.totalUpgrades} upgrades`);
+///   for (const pkg of result.data.packages) {
+///     console.log(`${pkg.packageName}:`);
+///     for (const dep of pkg.dependencies) {
+///       console.log(`  ${dep.name}: ${dep.currentVersion} -> ${dep.latestVersion}`);
+///     }
+///   }
+/// }
+/// ```
+///
+/// @example Safe upgrades only (no major version changes)
+/// ```typescript
+/// const result = await upgradeCheck({
+///   root: '/path/to/workspace',
+///   includeMajor: false,
+///   includeMinor: true,
+///   includePatch: true
+/// });
+/// if (result.success) {
+///   console.log(`Safe upgrades: ${result.data.summary.minorUpgrades + result.data.summary.patchUpgrades}`);
+/// }
+/// ```
+///
+/// @example Check specific packages
+/// ```typescript
+/// const result = await upgradeCheck({
+///   root: '.',
+///   packages: ['@scope/pkg1', '@scope/pkg2']
+/// });
+/// ```
+///
+/// @example Error handling
+/// ```typescript
+/// const result = await upgradeCheck({ root: '/invalid/path' });
+/// if (!result.success) {
+///   switch (result.error.code) {
+///     case 'ENOENT':
+///       console.error('Path not found');
+///       break;
+///     case 'EVALIDATION':
+///       console.error('Invalid parameters:', result.error.message);
+///       break;
+///     case 'ENETWORK':
+///       console.error('Network error - registry unreachable');
+///       break;
+///     default:
+///       console.error(`Error: ${result.error.message}`);
+///   }
+/// }
+/// ```
+#[napi]
+pub async fn upgrade_check(params: UpgradeCheckParams) -> UpgradeCheckApiResponse {
+    // 1. Validate parameters (synchronous validation before spawning)
+    let root_path = match validate_upgrade_check_params(&params) {
+        Ok(path) => path,
+        Err(error) => return UpgradeCheckApiResponse::failure(error),
+    };
+
+    // 2. Convert params to CLI args
+    let args = convert_params_to_args(&params);
+
+    // 3. Execute CLI command in a blocking task
+    // The CLI's execute_upgrade_check uses types that may not be Send/Sync,
+    // so we run it on a blocking thread via spawn_blocking.
+    let result = tokio::task::spawn_blocking(move || {
+        // Create a new tokio runtime for the blocking context
+        // This is necessary because execute_upgrade_check is async but we're in a blocking context
+        let rt = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+            Ok(rt) => rt,
+            Err(e) => {
+                return Err(ErrorInfo::execution(format!("Failed to create runtime: {e}")));
+            }
+        };
+
+        rt.block_on(async {
+            // Create shared buffer for output capture
+            let buffer = SharedBuffer::new();
+
+            // Create Output with JSON format
+            let output = Output::new(OutputFormat::Json, buffer.clone(), true);
+
+            // Execute the CLI command
+            if let Err(cli_error) = execute_upgrade_check(&args, &output, &root_path).await {
+                return Err(ErrorInfo::from(cli_error));
+            }
+
+            // Extract and parse JSON
+            let json_bytes = buffer.take_bytes();
+            parse_upgrade_check_response(&json_bytes)
+        })
+    })
+    .await;
+
+    // 4. Handle spawn_blocking result
+    match result {
+        Ok(Ok(data)) => UpgradeCheckApiResponse::success(data),
+        Ok(Err(error)) => UpgradeCheckApiResponse::failure(error),
+        Err(join_error) => UpgradeCheckApiResponse::failure(ErrorInfo::execution(format!(
+            "Task execution failed: {join_error}"
+        ))),
+    }
+}
+
+// ============================================================================
+// TODO: Story 8.3 - upgradeApply
+// ============================================================================
+
 // Implementation outline for upgradeApply:
 //
 // #[napi]
-// pub async fn upgrade_apply(params: UpgradeApplyParams) -> JsonResponse<UpgradeApplyData> {
+// pub async fn upgrade_apply(params: UpgradeApplyParams) -> UpgradeApplyApiResponse {
 //     // 1. Validate parameters
-//     if let Err(e) = validate_root(&params.root) {
-//         return JsonResponse::from_error_info(e);
+//     if let Err(e) = validate_upgrade_apply_params(&params) {
+//         return UpgradeApplyApiResponse::failure(e);
 //     }
 //
-//     // 2. Optionally create backup if params.create_backup is true
-//     // 3. Create UpgradeSelection from params.selection
+//     // 2. Convert params to CLI args
+//     // 3. Optionally create backup if params.create_backup is true
 //     // 4. Create Output with JSON format for capturing
-//     // 5. Call apply_upgrades or apply_with_changeset from sublime_pkg_tools
+//     // 5. Call execute_upgrade_apply from sublime_cli_tools
 //     // 6. Parse response with applied, skipped, failed counts
-//     // 7. Return JsonResponse::success(data) or JsonResponse::error(msg)
+//     // 7. Return UpgradeApplyApiResponse::success(data) or ::failure(error)
 // }
-//
-// Implementation outline for backupCreate:
+
+// ============================================================================
+// TODO: Story 8.4 - Backup Commands
+// ============================================================================
+
+// Implementation outline for backupList:
 //
 // #[napi]
-// pub async fn backup_create(params: BackupCreateParams) -> JsonResponse<BackupCreateData> {
+// pub async fn backup_list(params: BackupListParams) -> BackupListApiResponse {
 //     // 1. Validate parameters
-//     if let Err(e) = validate_root(&params.root) {
-//         return JsonResponse::from_error_info(e);
+//     if let Err(e) = validate_backup_list_params(&params) {
+//         return BackupListApiResponse::failure(e);
 //     }
 //
 //     // 2. Create BackupManager instance
-//     // 3. Call create_backup
-//     // 4. Return backup metadata (id, created_at, packages)
+//     // 3. Call list_backups
+//     // 4. Return list of backup metadata
 // }
 //
 // Implementation outline for backupRestore:
 //
 // #[napi]
-// pub async fn backup_restore(params: BackupRestoreParams) -> JsonResponse<BackupRestoreData> {
-//     // 1. Validate parameters
-//     if let Err(e) = validate_root(&params.root) {
-//         return JsonResponse::from_error_info(e);
+// pub async fn backup_restore(params: BackupRestoreParams) -> BackupRestoreApiResponse {
+//     // 1. Validate parameters (including backup_id not empty)
+//     if let Err(e) = validate_backup_restore_params(&params) {
+//         return BackupRestoreApiResponse::failure(e);
 //     }
-//     // Also validate backup_id is not empty
 //
 //     // 2. Create BackupManager instance
 //     // 3. Call restore_backup with the backup_id
 //     // 4. Return restore results
 // }
 //
-// Implementation outline for backupList:
+// Implementation outline for backupClean:
 //
 // #[napi]
-// pub async fn backup_list(params: BackupListParams) -> JsonResponse<BackupListData> {
+// pub async fn backup_clean(params: BackupCleanParams) -> BackupCleanApiResponse {
 //     // 1. Validate parameters
-//     if let Err(e) = validate_root(&params.root) {
-//         return JsonResponse::from_error_info(e);
+//     if let Err(e) = validate_backup_clean_params(&params) {
+//         return BackupCleanApiResponse::failure(e);
 //     }
 //
 //     // 2. Create BackupManager instance
-//     // 3. Call list_backups
-//     // 4. Return list of backup metadata
+//     // 3. Call clean_backups with keep_count
+//     // 4. Return cleanup results
 // }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -168,7 +168,12 @@ pub use commands::execute;
 pub use commands::config_show;
 // Story 7.3: configValidate
 pub use commands::config_validate;
-// TODO: will be implemented on story 8.2-8.4 (upgrade commands)
+
+// Upgrade commands (Story 8.2-8.4)
+// Story 8.2: upgradeCheck
+pub use commands::upgrade_check;
+// TODO: will be implemented on story 8.3 (upgradeApply)
+// TODO: will be implemented on story 8.4 (backupList, backupRestore, backupClean)
 // TODO: will be implemented on story 9.1-9.3 (remaining commands)
 
 /// Version of the crate.

--- a/packages/workspace-tools/npm/darwin-arm64/package.json
+++ b/packages/workspace-tools/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-arm64",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/darwin-x64/package.json
+++ b/packages/workspace-tools/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-darwin-x64",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-gnu",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-arm64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-arm64-musl",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-gnu/package.json
+++ b/packages/workspace-tools/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-gnu",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/linux-x64-musl/package.json
+++ b/packages/workspace-tools/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-linux-x64-musl",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/npm/win32-arm64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-arm64-msvc",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "cpu": [
     "arm64"
   ],

--- a/packages/workspace-tools/npm/win32-x64-msvc/package.json
+++ b/packages/workspace-tools/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools-win32-x64-msvc",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "cpu": [
     "x64"
   ],

--- a/packages/workspace-tools/package.json
+++ b/packages/workspace-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@websublime/workspace-tools",
-  "version": "2.0.23",
+  "version": "2.0.24",
   "description": "Bindings for node from crate workspace-tools",
   "main": "./dist/cjs/index.cjs",
   "types": "./dist/types/index.d.cts",

--- a/packages/workspace-tools/src/binding.d.ts
+++ b/packages/workspace-tools/src/binding.d.ts
@@ -7071,6 +7071,87 @@ export interface UpgradeApplyParams {
 }
 
 /**
+ * Check for available dependency upgrades.
+ *
+ * Detects which dependencies in the workspace have newer versions available
+ * from the npm registry. This is a read-only operation that does not modify
+ * any files.
+ *
+ * The function checks all packages in the workspace and returns a comprehensive
+ * list of available upgrades along with summary statistics.
+ *
+ * @param params - Upgrade check parameters containing:
+ *   - `root`: Workspace root directory path (required)
+ *   - `configPath`: Optional custom configuration file path
+ *   - `includeMajor`: Whether to include major version upgrades (default: true)
+ *   - `includeMinor`: Whether to include minor version upgrades (default: true)
+ *   - `includePatch`: Whether to include patch version upgrades (default: true)
+ *   - `includeDevDependencies`: Whether to check devDependencies (default: true)
+ *   - `includePeerDependencies`: Whether to check peerDependencies (default: false)
+ *   - `packages`: Optional list of packages to check (checks all if not specified)
+ *
+ * @returns `Promise<UpgradeCheckApiResponse>` containing:
+ *   - On success: `{ success: true, data: UpgradeCheckData }`
+ *   - On failure: `{ success: false, error: ErrorInfo }`
+ *
+ * @example Basic usage
+ * ```typescript
+ * const result = await upgradeCheck({ root: '.' });
+ * if (result.success) {
+ *   console.log(`Found ${result.data.summary.totalUpgrades} upgrades`);
+ *   for (const pkg of result.data.packages) {
+ *     console.log(`${pkg.packageName}:`);
+ *     for (const dep of pkg.dependencies) {
+ *       console.log(`  ${dep.name}: ${dep.currentVersion} -> ${dep.latestVersion}`);
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @example Safe upgrades only (no major version changes)
+ * ```typescript
+ * const result = await upgradeCheck({
+ *   root: '/path/to/workspace',
+ *   includeMajor: false,
+ *   includeMinor: true,
+ *   includePatch: true
+ * });
+ * if (result.success) {
+ *   console.log(`Safe upgrades: ${result.data.summary.minorUpgrades + result.data.summary.patchUpgrades}`);
+ * }
+ * ```
+ *
+ * @example Check specific packages
+ * ```typescript
+ * const result = await upgradeCheck({
+ *   root: '.',
+ *   packages: ['@scope/pkg1', '@scope/pkg2']
+ * });
+ * ```
+ *
+ * @example Error handling
+ * ```typescript
+ * const result = await upgradeCheck({ root: '/invalid/path' });
+ * if (!result.success) {
+ *   switch (result.error.code) {
+ *     case 'ENOENT':
+ *       console.error('Path not found');
+ *       break;
+ *     case 'EVALIDATION':
+ *       console.error('Invalid parameters:', result.error.message);
+ *       break;
+ *     case 'ENETWORK':
+ *       console.error('Network error - registry unreachable');
+ *       break;
+ *     default:
+ *       console.error(`Error: ${result.error.message}`);
+ *   }
+ * }
+ * ```
+ */
+export declare function upgradeCheck(params: UpgradeCheckParams): Promise<UpgradeCheckApiResponse>
+
+/**
  * API response for the upgrade check command.
  *
  * This structure wraps `UpgradeCheckData` in the standard `ApiResponse`

--- a/packages/workspace-tools/src/binding.js
+++ b/packages/workspace-tools/src/binding.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-android-arm-eabi')
         const bindingPackageVersion = require('@websublime/workspace-tools-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-x64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-ia32-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-win32-arm64-msvc')
         const bindingPackageVersion = require('@websublime/workspace-tools-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@websublime/workspace-tools-darwin-universal')
       const bindingPackageVersion = require('@websublime/workspace-tools-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-darwin-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-freebsd-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-x64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-musleabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-loong64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-musl')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@websublime/workspace-tools-linux-riscv64-gnu')
           const bindingPackageVersion = require('@websublime/workspace-tools-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-ppc64-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-linux-s390x-gnu')
         const bindingPackageVersion = require('@websublime/workspace-tools-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-x64')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@websublime/workspace-tools-openharmony-arm')
         const bindingPackageVersion = require('@websublime/workspace-tools-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '2.0.22' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 2.0.22 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '2.0.23' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 2.0.23 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -588,3 +588,4 @@ module.exports.execute = nativeBinding.execute
 module.exports.getVersion = nativeBinding.getVersion
 module.exports.init = nativeBinding.init
 module.exports.status = nativeBinding.status
+module.exports.upgradeCheck = nativeBinding.upgradeCheck

--- a/packages/workspace-tools/src/index.ts
+++ b/packages/workspace-tools/src/index.ts
@@ -23,6 +23,7 @@
  * - `execute()` - Execute commands across workspace packages with timeout support (Story 6.3)
  * - `configShow()` - Show current workspace configuration (Story 7.2)
  * - `configValidate()` - Validate workspace configuration (Story 7.3)
+ * - `upgradeCheck()` - Check for available dependency upgrades (Story 8.2)
  *
  * Config types (Story 7.1):
  * - `ConfigShowParams`, `ConfigShowData`, `ConfigShowApiResponse`
@@ -84,6 +85,7 @@ import {
   getVersion,
   init,
   status,
+  upgradeCheck,
 } from './binding'
 
 export {
@@ -103,6 +105,7 @@ export {
   getVersion,
   init,
   status,
+  upgradeCheck,
 }
 
 // Re-export all types from bindings


### PR DESCRIPTION
- Add upgrade_check function to commands/upgrade.rs with full implementation
- Add SharedBuffer for CLI output capture
- Add CLI response types for JSON parsing (CliUpgradeCheckData, etc.)
- Add conversion functions from CLI types to NAPI types
- Add parameter validation with positive logic API (includeMajor vs no_major)
- Export upgrade_check from commands/mod.rs and lib.rs
- Add comprehensive test suite (34 tests) in commands/tests.rs
- Update index.ts to re-export upgradeCheck function
- Bump version to 2.0.24

The upgradeCheck function allows Node.js/TypeScript applications to check for available dependency upgrades with filtering by upgrade type (major, minor, patch), dependency type (dev, peer), and specific packages.