### PR TITLE
feat(git): add HTTPS authentication support for remote operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,6 +2164,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -43,6 +43,7 @@ libgit2-sys = { version = "0.18", features = [
 # may not be available or compatible with the target architecture.
 libz-sys = { version = "1.1", features = ["static"] }
 dirs = { workspace = true }
+url = "2.5"
 
 [dev-dependencies]
 tempfile = "3.19.1"

--- a/crates/git/SPEC.md
+++ b/crates/git/SPEC.md
@@ -1042,6 +1042,52 @@ for file in package_changes {
 
 ## Remote Operations
 
+### Authentication
+
+Remote operations (push, pull, fetch) support both SSH and HTTPS authentication methods.
+The library automatically detects the appropriate authentication method based on the
+remote URL and available credentials.
+
+#### HTTPS Authentication
+
+For HTTPS remotes, credentials are resolved in the following priority order:
+
+1. **URL-embedded credentials**: Credentials embedded in the remote URL
+   (e.g., `https://user:token@github.com/repo.git`)
+
+2. **Environment variables** (checked in order):
+   - `GH_TOKEN` - GitHub token (commonly used in GitHub Actions)
+   - `GITHUB_TOKEN` - GitHub token (alternative)
+   - `GIT_TOKEN` - Generic Git token
+   - `GIT_USERNAME` + `GIT_PASSWORD` - Explicit username/password pair
+
+**GitHub Actions Example:**
+
+```yaml
+# Option 1: Configure git with token in URL
+- name: Configure Git
+  run: |
+    git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}.git
+
+# Option 2: Use environment variable (recommended)
+- name: Push changes
+  env:
+    GH_TOKEN: ${{ secrets.GH_TOKEN }}
+  run: workspace bump --execute --git-tag --git-push
+```
+
+#### SSH Authentication
+
+For SSH remotes, credentials are resolved in the following order:
+
+1. **Custom key paths**: If provided via `push_with_ssh_config`
+2. **Default key paths** (tried in order):
+   - `~/.ssh/id_ed25519` (preferred by GitHub)
+   - `~/.ssh/id_rsa` (widely used)
+   - `~/.ssh/id_ecdsa`
+   - `~/.ssh/id_dsa` (legacy)
+3. **SSH agent**: Falls back to the SSH agent if available
+
 ### Pushing and Pulling
 
 #### `Repo::push`
@@ -1059,6 +1105,11 @@ pub fn push(&self, remote_name: &str, follow_tags: Option<bool>) -> Result<bool,
 **Returns:**
 - `Result<bool, RepoError>`: True if push was successful, or an error
 
+**Authentication:**
+
+This method automatically handles authentication for both SSH and HTTPS remotes.
+See the [Authentication](#authentication) section for configuration details.
+
 **Example:**
 ```rust
 // Push without tags
@@ -1071,7 +1122,7 @@ repo.push("origin", Some(true))?;
 **Possible errors:**
 - `HeadError`: Failed to get repository HEAD
 - `BranchNameError`: Failed to get branch name
-- `RemoteError`: Failed to find or access remote
+- `RemoteError`: Failed to find or access remote (including authentication failures)
 - `PushError`: Failed to push to remote
 
 #### `Repo::pull`

--- a/crates/git/src/repo.rs
+++ b/crates/git/src/repo.rs
@@ -64,6 +64,7 @@ use std::collections::HashMap;
 use std::fs::canonicalize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use url::Url;
 
 use crate::{GitChangedFile, GitFileStatus, Repo, RepoCommit, RepoError, RepoTags};
 
@@ -2568,9 +2569,18 @@ impl Repo {
         // Create callbacks for credentials, progress reporting, etc.
         let mut callbacks = RemoteCallbacks::new();
 
-        // Setup SSH authentication with default key paths
-        callbacks.credentials(|url, username_from_url, allowed_types| {
-            self.create_ssh_credentials(url, username_from_url, allowed_types, None)
+        // Get the remote URL for credential extraction
+        let remote_url = remote.url().map(std::string::ToString::to_string);
+
+        // Setup authentication with support for both SSH and HTTPS
+        callbacks.credentials(move |url, username_from_url, allowed_types| {
+            Self::create_credentials(
+                url,
+                username_from_url,
+                allowed_types,
+                None,
+                remote_url.as_deref(),
+            )
         });
 
         // Add progress reporting
@@ -2657,9 +2667,18 @@ impl Repo {
         // Configure authentication
         let mut callbacks = RemoteCallbacks::new();
 
-        // Setup SSH authentication with default key paths
-        callbacks.credentials(|url, username_from_url, allowed_types| {
-            self.create_ssh_credentials(url, username_from_url, allowed_types, None)
+        // Get the remote URL for credential extraction
+        let remote_url = remote.url().map(std::string::ToString::to_string);
+
+        // Setup authentication with support for both SSH and HTTPS
+        callbacks.credentials(move |url, username_from_url, allowed_types| {
+            Self::create_credentials(
+                url,
+                username_from_url,
+                allowed_types,
+                None,
+                remote_url.as_deref(),
+            )
         });
 
         // Apply the callbacks
@@ -2905,8 +2924,17 @@ impl Repo {
         let mut callbacks = RemoteCallbacks::new();
         let key_paths = ssh_key_paths.clone(); // Clone for the closure
 
+        // Get the remote URL for credential extraction
+        let remote_url = remote.url().map(std::string::ToString::to_string);
+
         callbacks.credentials(move |url, username_from_url, allowed_types| {
-            self.create_ssh_credentials(url, username_from_url, allowed_types, Some(&key_paths))
+            Self::create_credentials(
+                url,
+                username_from_url,
+                allowed_types,
+                Some(&key_paths),
+                remote_url.as_deref(),
+            )
         });
 
         // Rest of push implementation is the same...
@@ -3573,26 +3601,180 @@ impl Repo {
         }
     }
 
-    /// Creates SSH credentials for Git operations
+    /// Creates credentials for Git operations (SSH or HTTPS)
     ///
-    /// This is an internal helper method used by push, fetch, etc.
+    /// This is an internal helper method used by push, fetch, etc. It automatically
+    /// detects whether SSH or HTTPS authentication is needed based on the `allowed_types`
+    /// parameter and attempts to provide appropriate credentials.
+    ///
+    /// # Authentication Methods
+    ///
+    /// ## HTTPS Authentication
+    ///
+    /// For HTTPS remotes, credentials are resolved in the following order:
+    ///
+    /// 1. **URL-embedded credentials**: Extracts username and password from the remote URL
+    ///    (e.g., `https://user:token@github.com/repo.git`)
+    /// 2. **Environment variables**: Checks for tokens in order:
+    ///    - `GH_TOKEN` - GitHub token (commonly used in GitHub Actions)
+    ///    - `GITHUB_TOKEN` - GitHub token (alternative)
+    ///    - `GIT_TOKEN` - Generic Git token
+    ///    - `GIT_USERNAME` + `GIT_PASSWORD` - Explicit username/password pair
+    ///
+    /// ## SSH Authentication
+    ///
+    /// For SSH remotes, credentials are resolved in the following order:
+    ///
+    /// 1. **Custom key paths**: If provided, tries each path in order
+    /// 2. **Default key paths**: Tries common SSH key locations:
+    ///    - `~/.ssh/id_ed25519` (preferred by GitHub)
+    ///    - `~/.ssh/id_rsa` (widely used)
+    ///    - `~/.ssh/id_ecdsa`
+    ///    - `~/.ssh/id_dsa` (legacy)
+    /// 3. **SSH agent**: Falls back to the SSH agent if available
     ///
     /// # Arguments
     ///
-    /// * `_url` - The remote URL
+    /// * `url` - The remote URL being accessed
+    /// * `username_from_url` - Optional username extracted from the URL by libgit2
+    /// * `allowed_types` - Types of credentials allowed by the remote
+    /// * `custom_key_paths` - Optional custom SSH key paths to try
+    /// * `remote_url` - Optional full remote URL for extracting embedded credentials
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Cred, Git2Error>` - Credentials or an error if authentication fails
+    ///
+    /// # Examples
+    ///
+    /// ## GitHub Actions with HTTPS
+    ///
+    /// In a GitHub Actions workflow, set up the remote with a token:
+    ///
+    /// ```yaml
+    /// # Configure git with token-based authentication
+    /// git remote set-url origin https://x-access-token:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}.git
+    /// ```
+    ///
+    /// Or use environment variables:
+    ///
+    /// ```yaml
+    /// env:
+    ///   GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    /// run: workspace bump --execute --git-tag --git-push
+    /// ```
+    pub(crate) fn create_credentials(
+        url: &str,
+        username_from_url: Option<&str>,
+        allowed_types: CredentialType,
+        custom_key_paths: Option<&Vec<PathBuf>>,
+        remote_url: Option<&str>,
+    ) -> Result<Cred, Git2Error> {
+        // Check if HTTPS authentication is requested (username/password or plaintext)
+        if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
+            return Self::create_https_credentials(url, username_from_url, remote_url);
+        }
+
+        // Check if SSH key authentication is requested
+        if allowed_types.contains(CredentialType::SSH_KEY) {
+            return Self::create_ssh_key_credentials(username_from_url, custom_key_paths);
+        }
+
+        // Check if only username is requested (some remotes query username first)
+        if allowed_types.contains(CredentialType::USERNAME) {
+            let username = username_from_url
+                .map(std::string::ToString::to_string)
+                .or_else(|| std::env::var("USER").ok())
+                .or_else(|| std::env::var("USERNAME").ok())
+                .unwrap_or_else(|| "git".to_string());
+            return Cred::username(&username);
+        }
+
+        // If default credentials are allowed, try that
+        if allowed_types.contains(CredentialType::DEFAULT) {
+            return Cred::default();
+        }
+
+        Err(Git2Error::from_str(
+            "No suitable authentication method available for the requested credential types",
+        ))
+    }
+
+    /// Creates HTTPS credentials for Git operations
+    ///
+    /// Attempts to create credentials for HTTPS authentication by checking:
+    /// 1. Embedded credentials in the remote URL
+    /// 2. Environment variables (GH_TOKEN, GITHUB_TOKEN, GIT_TOKEN)
+    /// 3. GIT_USERNAME and GIT_PASSWORD environment variables
+    ///
+    /// # Arguments
+    ///
+    /// * `_url` - The URL being accessed (from the credential callback)
+    /// * `username_from_url` - Optional username extracted from the URL by libgit2
+    /// * `remote_url` - Optional full remote URL for extracting embedded credentials
+    ///
+    /// # Returns
+    ///
+    /// * `Result<Cred, Git2Error>` - HTTPS credentials or an error
+    fn create_https_credentials(
+        _url: &str,
+        username_from_url: Option<&str>,
+        remote_url: Option<&str>,
+    ) -> Result<Cred, Git2Error> {
+        // First, try to extract credentials from the remote URL
+        if let Some(url_str) = remote_url
+            && let Ok(parsed_url) = Url::parse(url_str)
+        {
+            let username = parsed_url.username();
+            if !username.is_empty() {
+                let password = parsed_url.password().unwrap_or("");
+                return Cred::userpass_plaintext(username, password);
+            }
+        }
+
+        // Try environment variables for GitHub-style token authentication
+        // These are commonly used in CI/CD environments
+        let token_result = std::env::var("GH_TOKEN")
+            .or_else(|_| std::env::var("GITHUB_TOKEN"))
+            .or_else(|_| std::env::var("GIT_TOKEN"));
+
+        if let Ok(token) = token_result {
+            // Use the username from URL if available, otherwise use "x-access-token"
+            // which is the standard username for GitHub token authentication
+            let username = username_from_url.unwrap_or("x-access-token");
+            return Cred::userpass_plaintext(username, &token);
+        }
+
+        // Try explicit username/password environment variables
+        if let (Ok(username), Ok(password)) =
+            (std::env::var("GIT_USERNAME"), std::env::var("GIT_PASSWORD"))
+        {
+            return Cred::userpass_plaintext(&username, &password);
+        }
+
+        Err(Git2Error::from_str(
+            "No HTTPS credentials available. Set GH_TOKEN, GITHUB_TOKEN, GIT_TOKEN, \
+             or GIT_USERNAME/GIT_PASSWORD environment variables, or embed credentials in the remote URL.",
+        ))
+    }
+
+    /// Creates SSH key credentials for Git operations
+    ///
+    /// Attempts to create SSH credentials by trying:
+    /// 1. Custom key paths if provided
+    /// 2. Default SSH key locations (~/.ssh/id_ed25519, ~/.ssh/id_rsa, etc.)
+    /// 3. SSH agent as a fallback
+    ///
+    /// # Arguments
+    ///
     /// * `username_from_url` - Optional username extracted from the URL
-    /// * `_allowed_types` - Types of credentials allowed by the remote
     /// * `custom_key_paths` - Optional custom SSH key paths to try
     ///
     /// # Returns
     ///
     /// * `Result<Cred, Git2Error>` - SSH credentials or an error
-    #[allow(clippy::unused_self)]
-    fn create_ssh_credentials(
-        &self,
-        _url: &str,
+    fn create_ssh_key_credentials(
         username_from_url: Option<&str>,
-        _allowed_types: CredentialType,
         custom_key_paths: Option<&Vec<PathBuf>>,
     ) -> Result<Cred, Git2Error> {
         // Get the list of key paths to try
@@ -3608,10 +3790,8 @@ impl Repo {
                         home_dir.join(".ssh").join("id_dsa"),     // DSA (legacy)
                     ]
                 } else {
-                    // Fallback if we can't find home directory
-                    return Err(Git2Error::from_str(
-                        "Could not determine home directory for SSH keys",
-                    ));
+                    // Try SSH agent as last resort if we can't find home directory
+                    return Cred::ssh_key_from_agent(username_from_url.unwrap_or("git"));
                 }
             }
         };

--- a/crates/git/src/tests.rs
+++ b/crates/git/src/tests.rs
@@ -6,6 +6,7 @@ mod tests {
     use sublime_standard_tools::monorepo::{MonorepoDetector, MonorepoDetectorTrait};
 
     use crate::{GitFileStatus, Repo, RepoError};
+    use git2::CredentialType;
     use std::{
         env::temp_dir,
         fs::{File, canonicalize, create_dir, remove_dir_all},
@@ -991,5 +992,346 @@ mod tests {
         assert_eq!(detached_branch, String::from("feature/bff"));
 
         Ok(())
+    }
+
+    // ============================================================================
+    // Credential Authentication Tests
+    // ============================================================================
+
+    /// Helper function to safely set an environment variable for testing.
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe because modifying environment variables in a multi-threaded
+    /// context can cause data races. These tests should run with `--test-threads=1`
+    /// or be careful about which variables they modify.
+    unsafe fn set_env_var(key: &str, value: &str) {
+        // SAFETY: Caller guarantees single-threaded test execution
+        unsafe { std::env::set_var(key, value) };
+    }
+
+    /// Helper function to safely remove an environment variable for testing.
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe because modifying environment variables in a multi-threaded
+    /// context can cause data races.
+    unsafe fn remove_env_var(key: &str) {
+        // SAFETY: Caller guarantees single-threaded test execution
+        unsafe { std::env::remove_var(key) };
+    }
+
+    /// Cleans up all credential-related environment variables.
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe because it modifies environment variables.
+    unsafe fn cleanup_credential_env_vars() {
+        // SAFETY: Caller guarantees single-threaded test execution
+        unsafe {
+            remove_env_var("GH_TOKEN");
+            remove_env_var("GITHUB_TOKEN");
+            remove_env_var("GIT_TOKEN");
+            remove_env_var("GIT_USERNAME");
+            remove_env_var("GIT_PASSWORD");
+        }
+    }
+
+    /// Tests that HTTPS credentials can be extracted from URL with embedded credentials.
+    ///
+    /// This test does NOT require environment variable manipulation, so it's safe
+    /// to run in parallel with other tests.
+    #[test]
+    fn test_https_credentials_from_url() {
+        // This test uses URL-embedded credentials, so no env manipulation needed
+        let result = Repo::create_credentials(
+            "https://github.com/test/repo.git",
+            None,
+            CredentialType::USER_PASS_PLAINTEXT,
+            None,
+            Some("https://x-access-token:my-secret-token@github.com/test/repo.git"),
+        );
+
+        assert!(result.is_ok(), "Should create credentials from URL with embedded credentials");
+    }
+
+    /// Tests that SSH key credentials can be created using the SSH agent.
+    ///
+    /// This test does NOT require environment variable manipulation.
+    #[test]
+    fn test_ssh_credentials_from_agent() {
+        // This test attempts to create SSH credentials via the SSH agent
+        // It may fail if no SSH agent is running, which is acceptable
+        let result = Repo::create_credentials(
+            "git@github.com:test/repo.git",
+            Some("git"),
+            CredentialType::SSH_KEY,
+            None,
+            None,
+        );
+
+        // We can't guarantee SSH agent is available, so we just check it doesn't panic
+        // The result could be Ok or Err depending on the environment
+        // Either outcome is acceptable - we're just testing that it doesn't panic
+        let _ = result;
+    }
+
+    /// Tests that username-only credentials can be created.
+    ///
+    /// This test does NOT require environment variable manipulation.
+    #[test]
+    fn test_username_only_credentials() {
+        let result = Repo::create_credentials(
+            "https://github.com/test/repo.git",
+            Some("test-user"),
+            CredentialType::USERNAME,
+            None,
+            None,
+        );
+
+        assert!(result.is_ok(), "Should create username-only credentials");
+    }
+
+    /// Tests that default credentials can be requested.
+    ///
+    /// This test does NOT require environment variable manipulation.
+    #[test]
+    fn test_default_credentials() {
+        let result = Repo::create_credentials(
+            "https://github.com/test/repo.git",
+            None,
+            CredentialType::DEFAULT,
+            None,
+            None,
+        );
+
+        assert!(result.is_ok(), "Should create default credentials");
+    }
+
+    /// Tests credential priority: URL credentials take precedence over environment variables.
+    ///
+    /// This test uses URL-embedded credentials primarily, so it's less sensitive
+    /// to environment variable state.
+    #[test]
+    fn test_url_credentials_take_priority() {
+        // Even if GH_TOKEN were set, URL credentials should take priority
+        let result = Repo::create_credentials(
+            "https://github.com/test/repo.git",
+            None,
+            CredentialType::USER_PASS_PLAINTEXT,
+            None,
+            Some("https://url-user:url-password@github.com/test/repo.git"),
+        );
+
+        assert!(result.is_ok(), "Should create credentials from URL");
+    }
+
+    /// Tests that HTTPS credentials can be extracted from GH_TOKEN environment variable.
+    ///
+    /// # Safety
+    ///
+    /// This test modifies environment variables. It should be run with
+    /// `--test-threads=1` to avoid race conditions with other tests.
+    #[test]
+    fn test_https_credentials_from_gh_token_env() {
+        // SAFETY: We're in a test context and manipulating env vars that are
+        // specific to this test. Running with --test-threads=1 is recommended.
+        unsafe {
+            cleanup_credential_env_vars();
+            set_env_var("GH_TOKEN", "test-github-token-12345");
+        }
+
+        let result = Repo::create_credentials(
+            "https://github.com/test/repo.git",
+            None,
+            CredentialType::USER_PASS_PLAINTEXT,
+            None,
+            None,
+        );
+
+        // Clean up before assertion to ensure cleanup happens even on failure
+        unsafe {
+            cleanup_credential_env_vars();
+        }
+
+        assert!(result.is_ok(), "Should create credentials from GH_TOKEN");
+    }
+
+    /// Tests that HTTPS credentials can be extracted from GITHUB_TOKEN env var.
+    ///
+    /// # Safety
+    ///
+    /// This test modifies environment variables.
+    #[test]
+    fn test_https_credentials_from_github_token_env() {
+        // SAFETY: We're in a test context
+        unsafe {
+            cleanup_credential_env_vars();
+            set_env_var("GITHUB_TOKEN", "ghp_test-token-67890");
+        }
+
+        let result = Repo::create_credentials(
+            "https://github.com/test/repo.git",
+            None,
+            CredentialType::USER_PASS_PLAINTEXT,
+            None,
+            None,
+        );
+
+        unsafe {
+            cleanup_credential_env_vars();
+        }
+
+        assert!(result.is_ok(), "Should create credentials from GITHUB_TOKEN");
+    }
+
+    /// Tests that HTTPS credentials can be extracted from GIT_USERNAME/GIT_PASSWORD.
+    ///
+    /// # Safety
+    ///
+    /// This test modifies environment variables.
+    #[test]
+    fn test_https_credentials_from_username_password_env() {
+        // SAFETY: We're in a test context
+        unsafe {
+            cleanup_credential_env_vars();
+            set_env_var("GIT_USERNAME", "my-git-user");
+            set_env_var("GIT_PASSWORD", "my-git-password");
+        }
+
+        let result = Repo::create_credentials(
+            "https://github.com/test/repo.git",
+            None,
+            CredentialType::USER_PASS_PLAINTEXT,
+            None,
+            None,
+        );
+
+        unsafe {
+            cleanup_credential_env_vars();
+        }
+
+        assert!(result.is_ok(), "Should create credentials from GIT_USERNAME/GIT_PASSWORD");
+    }
+
+    /// Tests that HTTPS credential creation fails gracefully when no credentials available.
+    ///
+    /// # Safety
+    ///
+    /// This test modifies environment variables.
+    #[test]
+    fn test_https_credentials_fails_without_credentials() {
+        // SAFETY: We're in a test context
+        unsafe {
+            cleanup_credential_env_vars();
+        }
+
+        let result = Repo::create_credentials(
+            "https://github.com/test/repo.git",
+            None,
+            CredentialType::USER_PASS_PLAINTEXT,
+            None,
+            None,
+        );
+
+        assert!(result.is_err(), "Should fail when no HTTPS credentials are available");
+
+        // Use match pattern since Cred doesn't implement Debug
+        match result {
+            Err(error) => {
+                let error_message = error.message();
+                assert!(
+                    error_message.contains("No HTTPS credentials available"),
+                    "Error message should indicate missing credentials, got: {error_message}"
+                );
+            }
+            Ok(_) => unreachable!("Already asserted result.is_err()"),
+        }
+    }
+
+    /// Tests that GH_TOKEN takes priority over GITHUB_TOKEN.
+    ///
+    /// # Safety
+    ///
+    /// This test modifies environment variables.
+    #[test]
+    fn test_gh_token_priority_over_github_token() {
+        // SAFETY: We're in a test context
+        unsafe {
+            cleanup_credential_env_vars();
+            set_env_var("GH_TOKEN", "gh-token-primary");
+            set_env_var("GITHUB_TOKEN", "github-token-secondary");
+        }
+
+        let result = Repo::create_credentials(
+            "https://github.com/test/repo.git",
+            None,
+            CredentialType::USER_PASS_PLAINTEXT,
+            None,
+            None,
+        );
+
+        unsafe {
+            cleanup_credential_env_vars();
+        }
+
+        assert!(result.is_ok(), "Should create credentials from GH_TOKEN");
+    }
+
+    /// Tests that the username from URL is used when available for token auth.
+    ///
+    /// # Safety
+    ///
+    /// This test modifies environment variables.
+    #[test]
+    fn test_username_from_url_used_for_token_auth() {
+        // SAFETY: We're in a test context
+        unsafe {
+            cleanup_credential_env_vars();
+            set_env_var("GH_TOKEN", "test-token");
+        }
+
+        let result = Repo::create_credentials(
+            "https://github.com/test/repo.git",
+            Some("custom-user"),
+            CredentialType::USER_PASS_PLAINTEXT,
+            None,
+            None,
+        );
+
+        unsafe {
+            cleanup_credential_env_vars();
+        }
+
+        assert!(result.is_ok(), "Should create credentials with username from URL");
+    }
+
+    /// Tests credential creation with empty username in URL falls back to environment.
+    ///
+    /// # Safety
+    ///
+    /// This test modifies environment variables.
+    #[test]
+    fn test_url_with_empty_username_falls_back_to_env() {
+        // SAFETY: We're in a test context
+        unsafe {
+            cleanup_credential_env_vars();
+            set_env_var("GH_TOKEN", "fallback-token");
+        }
+
+        // URL without credentials should fall back to environment
+        let result = Repo::create_credentials(
+            "https://github.com/test/repo.git",
+            None,
+            CredentialType::USER_PASS_PLAINTEXT,
+            None,
+            Some("https://github.com/test/repo.git"),
+        );
+
+        unsafe {
+            cleanup_credential_env_vars();
+        }
+
+        assert!(result.is_ok(), "Should fall back to GH_TOKEN when URL has no credentials");
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: Remote operations (push, pull, fetch) now support both SSH and HTTPS authentication methods.

- Add HTTPS credential support with multiple sources:
  - URL-embedded credentials (https://user:token@host/repo.git)
  - Environment variables: GH_TOKEN, GITHUB_TOKEN, GIT_TOKEN
  - Explicit GIT_USERNAME/GIT_PASSWORD variables
- Refactor create_ssh_credentials into create_credentials with automatic detection of authentication method based on CredentialType
- Add create_https_credentials and create_ssh_key_credentials helper methods
- Update push, fetch, and push_with_ssh_config to use new authentication system
- Add url crate dependency for URL parsing
- Add comprehensive tests for credential authentication
- Update SPEC.md with authentication documentation

This resolves GitHub Actions authentication failures when using HTTPS remotes with token-based authentication (error: Auth -16).