### PR TITLE
fix(pkg): pass workspace patterns from config to MonorepoDetector

### DIFF
--- a/crates/cli/src/cli/dispatch.rs
+++ b/crates/cli/src/cli/dispatch.rs
@@ -255,8 +255,13 @@ pub async fn dispatch_command(cli: &Cli) -> Result<()> {
         },
 
         Commands::Audit(args) => {
-            audit::execute_audit(args, &output, root, config_path.as_ref().map(|p| p.as_path()))
-                .await?;
+            Box::pin(audit::execute_audit(
+                args,
+                &output,
+                root,
+                config_path.as_ref().map(|p| p.as_path()),
+            ))
+            .await?;
         }
 
         Commands::Changes(args) => {

--- a/crates/cli/src/commands/audit/tests.rs
+++ b/crates/cli/src/commands/audit/tests.rs
@@ -30,6 +30,7 @@
 //! - 100% test coverage goal is met
 
 #[cfg(test)]
+#[allow(clippy::large_futures)]
 mod comprehensive_tests {
     use crate::cli::commands::AuditArgs;
     use crate::commands::audit::comprehensive::execute_audit;
@@ -766,6 +767,7 @@ mod upgrade_report_formatting_tests {
 }
 
 #[cfg(test)]
+#[allow(clippy::large_futures)]
 mod dependency_audit_tests {
     use crate::commands::audit::dependencies::execute_dependency_audit;
     use crate::commands::audit::types::MinSeverity;

--- a/crates/cli/src/commands/changeset/add.rs
+++ b/crates/cli/src/commands/changeset/add.rs
@@ -223,7 +223,7 @@ pub async fn execute_add(
     // Detect affected packages from git if not provided
     let detected_packages = if args.packages.is_none() && !all_packages.is_empty() {
         debug!("Detecting affected packages from git changes");
-        detect_affected_packages(&workspace_root, &repo, &fs, &all_packages).await
+        detect_affected_packages(&workspace_root, &repo, &fs, &all_packages, &config).await
     } else {
         vec![]
     };
@@ -520,13 +520,14 @@ pub(crate) async fn detect_affected_packages(
     repo: &Repo,
     fs: &FileSystemManager,
     all_packages: &[String],
+    config: &sublime_pkg_tools::config::PackageToolsConfig,
 ) -> Vec<String> {
     use sublime_pkg_tools::changeset::PackageDetector;
 
     debug!("Detecting affected packages from git changes");
 
-    // Create PackageDetector
-    let detector = PackageDetector::new(workspace_root, repo, fs.clone());
+    // Create PackageDetector with config to use correct workspace patterns
+    let detector = PackageDetector::new_with_config(workspace_root, repo, fs.clone(), config);
 
     // Get commits by comparing current branch against base branch (main/master)
     // This ensures we only analyze commits that are part of the current feature branch

--- a/crates/cli/tests/e2e_audit.rs
+++ b/crates/cli/tests/e2e_audit.rs
@@ -21,6 +21,7 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::panic)]
 #![allow(clippy::unwrap_used)]
+#![allow(clippy::large_futures)]
 
 mod common;
 

--- a/crates/pkg/src/changes/analyzer.rs
+++ b/crates/pkg/src/changes/analyzer.rs
@@ -564,9 +564,12 @@ where
         // Convert git changed files to paths
         let changed_paths: Vec<PathBuf> = status.iter().map(|f| PathBuf::from(&f.path)).collect();
 
-        // Create package mapper
-        let mut package_mapper =
-            PackageMapper::with_filesystem(self.workspace_root.clone(), self.fs.clone());
+        // Create package mapper with config to use correct workspace patterns
+        let mut package_mapper = PackageMapper::with_filesystem_and_config(
+            self.workspace_root.clone(),
+            self.fs.clone(),
+            &self.config,
+        );
 
         // Map files to packages (not used directly but ensures cache is populated)
         let _files_by_package = package_mapper.map_files_to_packages(&changed_paths).await?;
@@ -745,9 +748,12 @@ where
         let changed_paths: Vec<PathBuf> =
             changed_files.iter().map(|f| PathBuf::from(&f.path)).collect();
 
-        // Create package mapper
-        let mut package_mapper =
-            PackageMapper::with_filesystem(self.workspace_root.clone(), self.fs.clone());
+        // Create package mapper with config to use correct workspace patterns
+        let mut package_mapper = PackageMapper::with_filesystem_and_config(
+            self.workspace_root.clone(),
+            self.fs.clone(),
+            &self.config,
+        );
 
         // Map files to packages
         let files_by_package = package_mapper.map_files_to_packages(&changed_paths).await?;

--- a/crates/pkg/src/changes/mapping.rs
+++ b/crates/pkg/src/changes/mapping.rs
@@ -68,11 +68,13 @@
 //! # }
 //! ```
 
+use crate::config::PackageToolsConfig;
 use crate::error::{ChangesError, ChangesResult};
 use crate::types::PackageInfo;
 use package_json::PackageJson;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use sublime_standard_tools::config::MonorepoConfig;
 use sublime_standard_tools::filesystem::{AsyncFileSystem, FileSystemManager};
 use sublime_standard_tools::monorepo::{
     MonorepoDescriptor, MonorepoDetector, MonorepoDetectorTrait,
@@ -172,6 +174,80 @@ impl PackageMapper<FileSystemManager> {
             file_cache: HashMap::new(),
         }
     }
+
+    /// Creates a new `PackageMapper` with the default filesystem and custom config.
+    ///
+    /// This constructor uses workspace patterns from the provided configuration,
+    /// ensuring that packages in directories like `playground/*` are discovered
+    /// correctly when specified in `repo.config.toml`.
+    ///
+    /// # Arguments
+    ///
+    /// * `workspace_root` - Root directory of the workspace
+    /// * `fs` - Filesystem instance for file operations
+    /// * `config` - Package tools configuration containing workspace patterns
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_pkg_tools::changes::mapping::PackageMapper;
+    /// use sublime_pkg_tools::config::PackageToolsConfig;
+    /// use sublime_standard_tools::filesystem::FileSystemManager;
+    /// use std::path::PathBuf;
+    ///
+    /// let workspace_root = PathBuf::from(".");
+    /// let fs = FileSystemManager::new();
+    /// let config = PackageToolsConfig::default();
+    /// let mapper = PackageMapper::new_with_config(workspace_root, fs, &config);
+    /// ```
+    #[must_use]
+    pub fn new_with_config(
+        workspace_root: PathBuf,
+        fs: FileSystemManager,
+        config: &PackageToolsConfig,
+    ) -> Self {
+        let monorepo_config = Self::build_monorepo_config(config);
+        let monorepo_detector =
+            MonorepoDetector::with_filesystem_and_config(fs.clone(), monorepo_config);
+
+        Self {
+            workspace_root,
+            fs,
+            monorepo_detector,
+            cached_monorepo: None,
+            file_cache: HashMap::new(),
+        }
+    }
+
+    /// Builds a `MonorepoConfig` from the `PackageToolsConfig`.
+    ///
+    /// This method creates a `MonorepoConfig` that includes workspace patterns from
+    /// the `repo.config.toml` file, ensuring all workspace directories are discovered.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The package tools configuration containing workspace patterns
+    ///
+    /// # Returns
+    ///
+    /// Returns a `MonorepoConfig` with merged workspace patterns.
+    #[must_use]
+    fn build_monorepo_config(config: &PackageToolsConfig) -> MonorepoConfig {
+        let mut monorepo_config = config.standard_config.monorepo.clone();
+
+        // Merge workspace patterns from repo.config.toml if available
+        if let Some(ref workspace) = config.workspace
+            && !workspace.patterns.is_empty()
+        {
+            for pattern in &workspace.patterns {
+                if !monorepo_config.workspace_patterns.contains(pattern) {
+                    monorepo_config.workspace_patterns.push(pattern.clone());
+                }
+            }
+        }
+
+        monorepo_config
+    }
 }
 
 impl<F> PackageMapper<F>
@@ -212,6 +288,81 @@ where
             cached_monorepo: None,
             file_cache: HashMap::new(),
         }
+    }
+
+    /// Creates a new `PackageMapper` with a custom filesystem and config.
+    ///
+    /// This constructor uses workspace patterns from the provided configuration,
+    /// ensuring that packages in all configured directories are discovered correctly.
+    ///
+    /// # Arguments
+    ///
+    /// * `workspace_root` - Root directory of the workspace
+    /// * `fs` - Custom filesystem implementation
+    /// * `config` - Package tools configuration containing workspace patterns
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_pkg_tools::changes::mapping::PackageMapper;
+    /// use sublime_pkg_tools::config::PackageToolsConfig;
+    /// use std::path::PathBuf;
+    ///
+    /// # async fn example<F>(fs: F, config: &PackageToolsConfig) -> Result<(), Box<dyn std::error::Error>>
+    /// # where F: AsyncFileSystem + Clone + Send + Sync + 'static
+    /// # {
+    /// let workspace_root = PathBuf::from(".");
+    /// let mapper = PackageMapper::with_filesystem_and_config(workspace_root, fs, config);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn with_filesystem_and_config(
+        workspace_root: PathBuf,
+        fs: F,
+        config: &PackageToolsConfig,
+    ) -> Self {
+        let monorepo_config = Self::build_monorepo_config_generic(config);
+        let monorepo_detector =
+            MonorepoDetector::with_filesystem_and_config(fs.clone(), monorepo_config);
+
+        Self {
+            workspace_root,
+            fs,
+            monorepo_detector,
+            cached_monorepo: None,
+            file_cache: HashMap::new(),
+        }
+    }
+
+    /// Builds a `MonorepoConfig` from the `PackageToolsConfig` (generic version).
+    ///
+    /// This method creates a `MonorepoConfig` that includes workspace patterns from
+    /// the `repo.config.toml` file, ensuring all workspace directories are discovered.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The package tools configuration containing workspace patterns
+    ///
+    /// # Returns
+    ///
+    /// Returns a `MonorepoConfig` with merged workspace patterns.
+    #[must_use]
+    fn build_monorepo_config_generic(config: &PackageToolsConfig) -> MonorepoConfig {
+        let mut monorepo_config = config.standard_config.monorepo.clone();
+
+        // Merge workspace patterns from repo.config.toml if available
+        if let Some(ref workspace) = config.workspace
+            && !workspace.patterns.is_empty()
+        {
+            for pattern in &workspace.patterns {
+                if !monorepo_config.workspace_patterns.contains(pattern) {
+                    monorepo_config.workspace_patterns.push(pattern.clone());
+                }
+            }
+        }
+
+        monorepo_config
     }
 
     /// Maps a list of files to their containing packages.

--- a/crates/pkg/src/changeset/git_integration.rs
+++ b/crates/pkg/src/changeset/git_integration.rs
@@ -12,10 +12,12 @@
 //! developers to quickly identify which packages need version bumps and should be included
 //! in a changeset, reducing manual work and potential errors in the release process.
 
+use crate::config::PackageToolsConfig;
 use crate::error::{ChangesetError, ChangesetResult};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use sublime_git_tools::{Repo, RepoCommit};
+use sublime_standard_tools::config::MonorepoConfig;
 use sublime_standard_tools::filesystem::{AsyncFileSystem, FileSystemManager};
 use sublime_standard_tools::monorepo::{MonorepoDetector, MonorepoDetectorTrait, WorkspacePackage};
 
@@ -91,6 +93,83 @@ impl<'a> PackageDetector<'a> {
         let workspace_root = workspace_root.into();
         let monorepo_detector = MonorepoDetector::with_filesystem(fs.clone());
         Self { workspace_root, repo, fs, monorepo_detector }
+    }
+
+    /// Creates a new `PackageDetector` with workspace patterns from configuration.
+    ///
+    /// This constructor uses workspace patterns from the provided configuration,
+    /// ensuring that packages in directories like `playground/*` are discovered
+    /// correctly when specified in `repo.config.toml`.
+    ///
+    /// # Parameters
+    ///
+    /// * `workspace_root` - The root directory of the workspace
+    /// * `repo` - Git repository instance
+    /// * `fs` - Filesystem manager
+    /// * `config` - Package tools configuration containing workspace patterns
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_pkg_tools::changeset::PackageDetector;
+    /// use sublime_pkg_tools::config::PackageToolsConfig;
+    /// use sublime_git_tools::Repo;
+    /// use sublime_standard_tools::filesystem::FileSystemManager;
+    /// use std::path::PathBuf;
+    ///
+    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let config = PackageToolsConfig::default();
+    /// let detector = PackageDetector::new_with_config(
+    ///     PathBuf::from("."),
+    ///     Repo::open(".")?,
+    ///     FileSystemManager::new(),
+    ///     &config,
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn new_with_config(
+        workspace_root: impl Into<PathBuf>,
+        repo: &'a Repo,
+        fs: FileSystemManager,
+        config: &PackageToolsConfig,
+    ) -> Self {
+        let workspace_root = workspace_root.into();
+        let monorepo_config = Self::build_monorepo_config(config);
+        let monorepo_detector =
+            MonorepoDetector::with_filesystem_and_config(fs.clone(), monorepo_config);
+        Self { workspace_root, repo, fs, monorepo_detector }
+    }
+
+    /// Builds a `MonorepoConfig` from the `PackageToolsConfig`.
+    ///
+    /// This method creates a `MonorepoConfig` that includes workspace patterns from
+    /// the `repo.config.toml` file, ensuring all workspace directories are discovered.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The package tools configuration containing workspace patterns
+    ///
+    /// # Returns
+    ///
+    /// Returns a `MonorepoConfig` with merged workspace patterns.
+    #[must_use]
+    fn build_monorepo_config(config: &PackageToolsConfig) -> MonorepoConfig {
+        let mut monorepo_config = config.standard_config.monorepo.clone();
+
+        // Merge workspace patterns from repo.config.toml if available
+        if let Some(ref workspace) = config.workspace
+            && !workspace.patterns.is_empty()
+        {
+            for pattern in &workspace.patterns {
+                if !monorepo_config.workspace_patterns.contains(pattern) {
+                    monorepo_config.workspace_patterns.push(pattern.clone());
+                }
+            }
+        }
+
+        monorepo_config
     }
 
     /// Detects packages affected by the given commits.

--- a/crates/pkg/src/changeset/manager.rs
+++ b/crates/pkg/src/changeset/manager.rs
@@ -11,7 +11,7 @@
 //! error handling, and storage coordination, making it easy to work with changesets throughout
 //! the application.
 
-use crate::config::ChangesetConfig;
+use crate::config::{ChangesetConfig, PackageToolsConfig};
 use crate::error::{ChangesetError, ChangesetResult};
 use crate::types::{Changeset, UpdateSummary, VersionBump};
 use std::path::PathBuf;
@@ -77,6 +77,11 @@ pub struct ChangesetManager<S: ChangesetStorage> {
     git_repo: Option<Repo>,
     /// Configuration for changeset validation and behavior.
     config: ChangesetConfig,
+    /// Full package tools configuration for workspace patterns.
+    ///
+    /// This is needed to pass workspace patterns to `PackageDetector` when
+    /// detecting packages affected by Git commits.
+    full_config: PackageToolsConfig,
 }
 
 impl ChangesetManager<FileBasedChangesetStorage<FileSystemManager>> {
@@ -124,7 +129,7 @@ impl ChangesetManager<FileBasedChangesetStorage<FileSystemManager>> {
         config: crate::config::PackageToolsConfig,
     ) -> ChangesetResult<Self> {
         let workspace_root = workspace_root.into();
-        let changeset_config = config.changeset;
+        let changeset_config = config.changeset.clone();
 
         // Create storage with configured paths
         let storage = FileBasedChangesetStorage::new(
@@ -137,7 +142,13 @@ impl ChangesetManager<FileBasedChangesetStorage<FileSystemManager>> {
         // Attempt to open Git repository (non-fatal if it fails)
         let git_repo = Repo::open(workspace_root.to_string_lossy().as_ref()).ok();
 
-        Ok(Self { storage, workspace_root, git_repo, config: changeset_config })
+        Ok(Self {
+            storage,
+            workspace_root,
+            git_repo,
+            config: changeset_config,
+            full_config: config,
+        })
     }
 }
 
@@ -151,8 +162,9 @@ impl<S: ChangesetStorage> ChangesetManager<S> {
     /// # Parameters
     ///
     /// * `storage` - The storage implementation to use
+    /// * `workspace_root` - The root directory of the workspace
     /// * `git_repo` - Optional Git repository for commit integration
-    /// * `config` - Changeset configuration for validation
+    /// * `full_config` - Full package tools configuration (includes workspace patterns)
     ///
     /// # Returns
     ///
@@ -162,11 +174,12 @@ impl<S: ChangesetStorage> ChangesetManager<S> {
     ///
     /// ```rust,ignore
     /// use sublime_pkg_tools::changeset::{ChangesetManager, FileBasedChangesetStorage};
-    /// use sublime_pkg_tools::config::ChangesetConfig;
+    /// use sublime_pkg_tools::config::PackageToolsConfig;
     /// use sublime_standard_tools::filesystem::FileSystemManager;
     /// use std::path::PathBuf;
     ///
     /// # fn example() {
+    /// let config = PackageToolsConfig::default();
     /// let storage = FileBasedChangesetStorage::new(
     ///     PathBuf::from("."),
     ///     ".changesets",
@@ -176,8 +189,9 @@ impl<S: ChangesetStorage> ChangesetManager<S> {
     ///
     /// let manager = ChangesetManager::with_storage(
     ///     storage,
+    ///     PathBuf::from("."),
     ///     None,
-    ///     ChangesetConfig::default()
+    ///     config
     /// );
     /// # }
     /// ```
@@ -186,9 +200,16 @@ impl<S: ChangesetStorage> ChangesetManager<S> {
         storage: S,
         workspace_root: impl Into<PathBuf>,
         git_repo: Option<Repo>,
-        config: ChangesetConfig,
+        full_config: PackageToolsConfig,
     ) -> Self {
-        Self { storage, workspace_root: workspace_root.into(), git_repo, config }
+        let changeset_config = full_config.changeset.clone();
+        Self {
+            storage,
+            workspace_root: workspace_root.into(),
+            git_repo,
+            config: changeset_config,
+            full_config,
+        }
     }
 
     /// Creates a new changeset.
@@ -645,8 +666,12 @@ impl<S: ChangesetStorage> ChangesetManager<S> {
         let since_commit = changeset.changes.last().cloned();
 
         // Get new commits from Git
-        let detector =
-            PackageDetector::new(self.workspace_root.clone(), repo, FileSystemManager::new());
+        let detector = PackageDetector::new_with_config(
+            self.workspace_root.clone(),
+            repo,
+            FileSystemManager::new(),
+            &self.full_config,
+        );
 
         let new_commits = detector.get_commits_since(since_commit)?;
 

--- a/crates/pkg/src/changeset/tests.rs
+++ b/crates/pkg/src/changeset/tests.rs
@@ -1138,16 +1138,19 @@ mod manager_tests {
         }
     }
 
-    fn create_test_config() -> ChangesetConfig {
-        ChangesetConfig {
-            path: ".changesets".into(),
-            history_path: ".changesets/history".into(),
-            available_environments: vec![
-                "development".to_string(),
-                "staging".to_string(),
-                "production".to_string(),
-            ],
-            default_environments: vec!["production".to_string()],
+    fn create_test_config() -> crate::config::PackageToolsConfig {
+        crate::config::PackageToolsConfig {
+            changeset: ChangesetConfig {
+                path: ".changesets".into(),
+                history_path: ".changesets/history".into(),
+                available_environments: vec![
+                    "development".to_string(),
+                    "staging".to_string(),
+                    "production".to_string(),
+                ],
+                default_environments: vec!["production".to_string()],
+            },
+            ..Default::default()
         }
     }
 
@@ -1464,10 +1467,7 @@ mod manager_tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let fs = FileSystemManager::new();
 
-        let config = crate::config::PackageToolsConfig {
-            changeset: create_test_config(),
-            ..Default::default()
-        };
+        let config = create_test_config();
 
         let manager =
             ChangesetManager::new(temp_dir.path().to_path_buf(), fs, config).await.unwrap();
@@ -2123,11 +2123,14 @@ mod git_integration_tests {
             FileSystemManager::new(),
         );
 
-        let config = ChangesetConfig {
-            path: ".changesets".into(),
-            history_path: ".changesets/history".into(),
-            available_environments: vec!["production".to_string()],
-            default_environments: vec!["production".to_string()],
+        let config = crate::config::PackageToolsConfig {
+            changeset: ChangesetConfig {
+                path: ".changesets".into(),
+                history_path: ".changesets/history".into(),
+                available_environments: vec!["production".to_string()],
+                default_environments: vec!["production".to_string()],
+            },
+            ..Default::default()
         };
 
         let manager = ChangesetManager::with_storage(
@@ -2205,11 +2208,14 @@ mod git_integration_tests {
             FileSystemManager::new(),
         );
 
-        let config = ChangesetConfig {
-            path: ".changesets".into(),
-            history_path: ".changesets/history".into(),
-            available_environments: vec!["production".to_string()],
-            default_environments: vec!["production".to_string()],
+        let config = crate::config::PackageToolsConfig {
+            changeset: ChangesetConfig {
+                path: ".changesets".into(),
+                history_path: ".changesets/history".into(),
+                available_environments: vec!["production".to_string()],
+                default_environments: vec!["production".to_string()],
+            },
+            ..Default::default()
         };
 
         let manager = ChangesetManager::with_storage(
@@ -2271,11 +2277,14 @@ mod git_integration_tests {
             FileSystemManager::new(),
         );
 
-        let config = ChangesetConfig {
-            path: ".changesets".into(),
-            history_path: ".changesets/history".into(),
-            available_environments: vec!["production".to_string()],
-            default_environments: vec!["production".to_string()],
+        let config = crate::config::PackageToolsConfig {
+            changeset: ChangesetConfig {
+                path: ".changesets".into(),
+                history_path: ".changesets/history".into(),
+                available_environments: vec!["production".to_string()],
+                default_environments: vec!["production".to_string()],
+            },
+            ..Default::default()
         };
 
         // Create manager without Git repo

--- a/crates/pkg/src/upgrade/application/changeset/tests.rs
+++ b/crates/pkg/src/upgrade/application/changeset/tests.rs
@@ -6,7 +6,7 @@
 use super::applier::{apply_with_changeset, extract_affected_packages};
 use super::creator::create_changeset_for_upgrades;
 use crate::changeset::{ChangesetManager, FileBasedChangesetStorage};
-use crate::config::{ChangesetConfig, UpgradeConfig};
+use crate::config::UpgradeConfig;
 use crate::error::UpgradeError;
 use crate::types::{DependencyType, VersionBump};
 use crate::upgrade::UpgradeSelection;
@@ -84,14 +84,14 @@ async fn setup_changeset_manager(
     workspace_root: &PathBuf,
 ) -> ChangesetManager<FileBasedChangesetStorage<FileSystemManager>> {
     let fs = FileSystemManager::new();
-    let config = ChangesetConfig::default();
+    let config = crate::config::PackageToolsConfig::default();
     let repo_path_str = workspace_root.to_str().expect("Invalid path");
     let repo = Repo::open(repo_path_str).ok();
 
     let storage = FileBasedChangesetStorage::new(
         workspace_root.clone(),
-        config.path.clone(),
-        config.history_path.clone(),
+        config.changeset.path.clone(),
+        config.changeset.history_path.clone(),
         fs,
     );
     ChangesetManager::with_storage(storage, workspace_root, repo, config)

--- a/crates/pkg/src/version/resolver.rs
+++ b/crates/pkg/src/version/resolver.rs
@@ -23,6 +23,7 @@ use crate::version::resolution::{PackageUpdate, VersionResolution, resolve_versi
 use package_json::PackageJson;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use sublime_standard_tools::config::MonorepoConfig;
 use sublime_standard_tools::filesystem::{AsyncFileSystem, FileSystemManager};
 use sublime_standard_tools::monorepo::{MonorepoDetector, MonorepoDetectorTrait, WorkspacePackage};
 
@@ -195,9 +196,12 @@ impl<F: AsyncFileSystem + Clone + Send + Sync + 'static> VersionResolver<F> {
             });
         }
 
+        // Build monorepo config with workspace patterns from repo.config.toml
+        let monorepo_config = Self::build_monorepo_config(&config);
+
         // Detect if monorepo or single package
         // This will also validate that the workspace root is a valid directory
-        let is_monorepo = Self::detect_monorepo(&workspace_root, &fs).await?;
+        let is_monorepo = Self::detect_monorepo(&workspace_root, &fs, &monorepo_config).await?;
 
         // Extract strategy from config
         let strategy = match config.version.strategy {
@@ -366,6 +370,51 @@ impl<F: AsyncFileSystem + Clone + Send + Sync + 'static> VersionResolver<F> {
         }
     }
 
+    /// Builds a `MonorepoConfig` from the `PackageToolsConfig`.
+    ///
+    /// This method creates a `MonorepoConfig` that includes workspace patterns from
+    /// the `repo.config.toml` file. It merges the project-specific patterns with
+    /// the standard configuration patterns to ensure all workspace directories
+    /// are discovered correctly.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - The package tools configuration containing workspace patterns
+    ///
+    /// # Returns
+    ///
+    /// Returns a `MonorepoConfig` with merged workspace patterns.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use sublime_pkg_tools::config::PackageToolsConfig;
+    /// use sublime_pkg_tools::version::VersionResolver;
+    ///
+    /// let config = PackageToolsConfig::default();
+    /// let monorepo_config = VersionResolver::<FileSystemManager>::build_monorepo_config(&config);
+    /// ```
+    #[must_use]
+    pub fn build_monorepo_config(config: &PackageToolsConfig) -> MonorepoConfig {
+        let mut monorepo_config = config.standard_config.monorepo.clone();
+
+        // Merge workspace patterns from repo.config.toml if available
+        // These patterns are project-specific and take precedence
+        if let Some(ref workspace) = config.workspace
+            && !workspace.patterns.is_empty()
+        {
+            // Add project-specific patterns to the config
+            // We add them to ensure they're included in package discovery
+            for pattern in &workspace.patterns {
+                if !monorepo_config.workspace_patterns.contains(pattern) {
+                    monorepo_config.workspace_patterns.push(pattern.clone());
+                }
+            }
+        }
+
+        monorepo_config
+    }
+
     /// Detects whether the workspace is a monorepo.
     ///
     /// This method uses `MonorepoDetector` from `sublime_standard_tools` to determine
@@ -375,6 +424,7 @@ impl<F: AsyncFileSystem + Clone + Send + Sync + 'static> VersionResolver<F> {
     ///
     /// * `workspace_root` - Root directory to check
     /// * `fs` - Filesystem implementation
+    /// * `monorepo_config` - Configuration containing workspace patterns
     ///
     /// # Returns
     ///
@@ -383,8 +433,13 @@ impl<F: AsyncFileSystem + Clone + Send + Sync + 'static> VersionResolver<F> {
     /// # Errors
     ///
     /// Returns `VersionError::FileSystemError` if detection fails.
-    async fn detect_monorepo(workspace_root: &Path, fs: &F) -> VersionResult<bool> {
-        let detector = MonorepoDetector::with_filesystem(fs.clone());
+    async fn detect_monorepo(
+        workspace_root: &Path,
+        fs: &F,
+        monorepo_config: &MonorepoConfig,
+    ) -> VersionResult<bool> {
+        let detector =
+            MonorepoDetector::with_filesystem_and_config(fs.clone(), monorepo_config.clone());
 
         // Check if this is a monorepo root
         let monorepo_kind = detector.is_monorepo_root(workspace_root).await.map_err(|e| {
@@ -411,7 +466,10 @@ impl<F: AsyncFileSystem + Clone + Send + Sync + 'static> VersionResolver<F> {
     /// Returns `VersionError::PackageNotFound` if no packages are found.
     /// Returns `VersionError::PackageJsonError` if package.json files cannot be read or parsed.
     async fn discover_monorepo_packages(&self) -> VersionResult<Vec<PackageInfo>> {
-        let detector = MonorepoDetector::with_filesystem(self.fs.clone());
+        // Build monorepo config with workspace patterns from repo.config.toml
+        let monorepo_config = Self::build_monorepo_config(&self.config);
+        let detector =
+            MonorepoDetector::with_filesystem_and_config(self.fs.clone(), monorepo_config);
 
         // Detect the monorepo structure
         let monorepo = detector.detect_monorepo(&self.workspace_root).await.map_err(|e| {


### PR DESCRIPTION
The CLI was failing to find packages in directories like 'playground/*' despite being configured in repo.config.toml with patterns = ["packages/*", "playground/*"].

Root cause: MonorepoDetector was being created with default configuration instead of using the workspace patterns from repo.config.toml.

Changes:
- Add build_monorepo_config() to VersionResolver to merge workspace patterns from PackageToolsConfig into MonorepoConfig
- Update detect_monorepo() and discover_monorepo_packages() to use MonorepoDetector::with_filesystem_and_config()
- Add new_with_config() and with_filesystem_and_config() constructors to PackageMapper for passing config with workspace patterns
- Add new_with_config() to PackageDetector for config-aware detection
- Add full_config field to ChangesetManager to store complete config
- Update ChangesAnalyzer to use PackageMapper::with_filesystem_and_config()
- Update detect_affected_packages() in CLI to pass config parameter

Also fixes:
- Pre-existing large_futures clippy warning in dispatch.rs
- Add #[allow(clippy::large_futures)] to audit test modules
- Fix field_reassign_with_default warnings in changeset tests

BREAKING CHANGE: ChangesetManager::with_storage() now requires PackageToolsConfig instead of ChangesetConfig