### PR TITLE
feat(workspace-fs): implement async FileSystem trait with 24 methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"

--- a/crates/filesystem/src/lib.rs
+++ b/crates/filesystem/src/lib.rs
@@ -128,7 +128,7 @@ pub use types::{DirEntry, FileType, Metadata};
 // Path extension utilities
 pub use path_ext::PathExt;
 
-// TODO: Re-exports will be added as modules are implemented
+// Trait re-export
 // pub use mock::MockFileSystem;
 // pub use real::RealFileSystem;
-// pub use traits::FileSystem;
+pub use traits::FileSystem;

--- a/crates/filesystem/src/traits.rs
+++ b/crates/filesystem/src/traits.rs
@@ -59,8 +59,8 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::types::{DirEntry, Metadata};
 use crate::Result;
+use crate::types::{DirEntry, Metadata};
 
 // =============================================================================
 // FileSystem Trait

--- a/crates/filesystem/src/traits.rs
+++ b/crates/filesystem/src/traits.rs
@@ -10,11 +10,14 @@
 //!
 //! ## How
 //!
-//! The trait uses `async_trait` to enable async methods in traits, which Rust does not
-//! natively support with object safety. Each method:
+//! The trait uses **native `async fn` in traits** (stabilized in Rust 1.75+, fully
+//! usable with `Send` bounds in Edition 2024). Each method:
 //! - Takes `&self` to allow shared access (implementations handle internal synchronization)
-//! - Accepts paths as `impl AsRef<Path>` for ergonomic use with `&str`, `String`, `PathBuf`, etc.
-//! - Returns `Result<T, Error>` using the crate's error type
+//! - Accepts paths as `&Path` for explicit, zero-cost path references
+//! - Returns `Result<T>` using the crate's error type (except metadata queries which return `bool`)
+//!
+//! The trait requires `Send + Sync` to ensure implementations are safe to share across
+//! async task boundaries.
 //!
 //! Two implementations are provided:
 //! - [`RealFileSystem`](crate::RealFileSystem): Production implementation using `tokio::fs`
@@ -27,6 +30,11 @@
 //! - **Testing**: Swap in `MockFileSystem` for fast, deterministic unit tests
 //! - **Flexibility**: Could add other implementations (e.g., cached, logged, remote)
 //! - **Decoupling**: Application code doesn't depend on specific filesystem implementation
+//! - **Zero Overhead**: Native async traits avoid the heap allocation of `async_trait`
+//!
+//! Using generics (`impl FileSystem` or `<FS: FileSystem>`) rather than `dyn FileSystem`
+//! enables monomorphization and avoids dynamic dispatch overhead. See
+//! [`docs/DECISIONS.md`](../../../docs/DECISIONS.md) ADR-001 for rationale.
 //!
 //! ## Example
 //!
@@ -45,9 +53,748 @@
 //!
 //! // In tests
 //! let mock = MockFileSystem::new();
-//! mock.write("config.json", r#"{"key": "value"}"#).await?;
+//! mock.write_string(Path::new("config.json"), r#"{"key": "value"}"#).await?;
 //! let content = read_json(&mock, Path::new("config.json")).await?;
 //! ```
 
-// TODO: will be implemented on epic workspace-node-tools-hek (FileSystem Trait)
-#![allow(clippy::todo)]
+use std::path::{Path, PathBuf};
+
+use crate::types::{DirEntry, Metadata};
+use crate::Result;
+
+// =============================================================================
+// FileSystem Trait
+// =============================================================================
+
+/// Unified asynchronous filesystem abstraction.
+///
+/// This trait defines the complete set of filesystem operations used throughout
+/// the workspace-node-tools ecosystem. It is the primary abstraction boundary
+/// that enables dependency injection and testability.
+///
+/// # Design
+///
+/// - **Native async**: Uses Rust's built-in `async fn` in traits (no `async_trait` macro)
+/// - **`Send + Sync`**: All implementations must be safe to share across async tasks
+/// - **Generic dispatch**: Consumers use `<FS: FileSystem>` for zero-cost monomorphization
+/// - **`&Path` parameters**: Explicit path references avoid hidden allocations
+///
+/// # Method Categories
+///
+/// | Category | Methods | PRD Reference |
+/// |----------|---------|---------------|
+/// | Read | [`read_to_string`][Self::read_to_string], [`read_bytes`][Self::read_bytes] | FR-1.2 |
+/// | Write | [`write_string`][Self::write_string], [`write_bytes`][Self::write_bytes], [`append_string`][Self::append_string], [`append_bytes`][Self::append_bytes] | FR-1.3 |
+/// | Metadata | [`exists`][Self::exists], [`is_file`][Self::is_file], [`is_dir`][Self::is_dir], [`is_symlink`][Self::is_symlink], [`metadata`][Self::metadata], [`symlink_metadata`][Self::symlink_metadata] | FR-1.4 |
+/// | Directory | [`create_dir`][Self::create_dir], [`create_dir_all`][Self::create_dir_all], [`read_dir`][Self::read_dir], [`remove_dir`][Self::remove_dir], [`remove_dir_all`][Self::remove_dir_all] | FR-1.5 |
+/// | File | [`remove_file`][Self::remove_file], [`copy_file`][Self::copy_file], [`rename`][Self::rename] | FR-1.6 |
+/// | Path | [`canonicalize`][Self::canonicalize], [`absolute`][Self::absolute] | FR-1.7 |
+/// | Symlink | [`read_link`][Self::read_link] | FR-1.8 |
+/// | Traversal | [`walk_dir`][Self::walk_dir] | FR-1.9 |
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use workspace_fs::FileSystem;
+/// use std::path::Path;
+///
+/// async fn count_json_files<FS: FileSystem>(fs: &FS, dir: &Path) -> usize {
+///     let entries = fs.read_dir(dir).await.unwrap_or_default();
+///     entries.iter().filter(|e| {
+///         e.path().extension().is_some_and(|ext| ext == "json")
+///     }).count()
+/// }
+/// ```
+#[allow(async_fn_in_trait)]
+pub trait FileSystem: Send + Sync {
+    // =========================================================================
+    // Read Operations (FR-1.2)
+    // =========================================================================
+
+    /// Reads the entire contents of a file as a UTF-8 string.
+    ///
+    /// Implements FR-1.2.1: Read file contents as a string.
+    ///
+    /// This is the primary method for reading text files such as configuration
+    /// files, JSON documents, TOML manifests, and changelogs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is a directory ([`Error::NotAFile`](crate::Error::NotAFile))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - The file content is not valid UTF-8 ([`Error::InvalidUtf8`](crate::Error::InvalidUtf8))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn read_config<FS: FileSystem>(fs: &FS) -> workspace_fs::Result<String> {
+    ///     fs.read_to_string(Path::new("package.json")).await
+    /// }
+    /// ```
+    async fn read_to_string(&self, path: &Path) -> Result<String>;
+
+    /// Reads the entire contents of a file as raw bytes.
+    ///
+    /// Implements FR-1.2.2: Read file contents as bytes.
+    ///
+    /// Use this method when you need the raw binary content of a file, or when
+    /// the file may not contain valid UTF-8 data.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is a directory ([`Error::NotAFile`](crate::Error::NotAFile))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn read_binary<FS: FileSystem>(fs: &FS, path: &Path) -> workspace_fs::Result<Vec<u8>> {
+    ///     fs.read_bytes(path).await
+    /// }
+    /// ```
+    async fn read_bytes(&self, path: &Path) -> Result<Vec<u8>>;
+
+    // =========================================================================
+    // Write Operations (FR-1.3)
+    // =========================================================================
+
+    /// Writes a UTF-8 string to a file, creating it if it does not exist
+    /// or truncating it if it does.
+    ///
+    /// Implements FR-1.3.1: Write string content to a file.
+    ///
+    /// Parent directories must already exist. Use [`create_dir_all`][Self::create_dir_all]
+    /// first if needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The parent directory does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is a directory ([`Error::NotAFile`](crate::Error::NotAFile))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn save_config<FS: FileSystem>(fs: &FS, content: &str) -> workspace_fs::Result<()> {
+    ///     fs.write_string(Path::new("config.json"), content).await
+    /// }
+    /// ```
+    async fn write_string(&self, path: &Path, content: &str) -> Result<()>;
+
+    /// Writes raw bytes to a file, creating it if it does not exist
+    /// or truncating it if it does.
+    ///
+    /// Implements FR-1.3.2: Write binary content to a file.
+    ///
+    /// Parent directories must already exist. Use [`create_dir_all`][Self::create_dir_all]
+    /// first if needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The parent directory does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is a directory ([`Error::NotAFile`](crate::Error::NotAFile))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn save_binary<FS: FileSystem>(fs: &FS, data: &[u8]) -> workspace_fs::Result<()> {
+    ///     fs.write_bytes(Path::new("output.bin"), data).await
+    /// }
+    /// ```
+    async fn write_bytes(&self, path: &Path, content: &[u8]) -> Result<()>;
+
+    /// Appends a UTF-8 string to a file, creating it if it does not exist.
+    ///
+    /// Implements FR-1.3.3: Append string content to a file.
+    ///
+    /// Unlike [`write_string`][Self::write_string], this method does not truncate
+    /// existing content. New content is added at the end of the file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The parent directory does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is a directory ([`Error::NotAFile`](crate::Error::NotAFile))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn append_log<FS: FileSystem>(fs: &FS, entry: &str) -> workspace_fs::Result<()> {
+    ///     fs.append_string(Path::new("debug.log"), entry).await
+    /// }
+    /// ```
+    async fn append_string(&self, path: &Path, content: &str) -> Result<()>;
+
+    /// Appends raw bytes to a file, creating it if it does not exist.
+    ///
+    /// Implements FR-1.3.4: Append binary content to a file.
+    ///
+    /// Unlike [`write_bytes`][Self::write_bytes], this method does not truncate
+    /// existing content. New content is added at the end of the file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The parent directory does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is a directory ([`Error::NotAFile`](crate::Error::NotAFile))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn append_data<FS: FileSystem>(fs: &FS, data: &[u8]) -> workspace_fs::Result<()> {
+    ///     fs.append_bytes(Path::new("output.bin"), data).await
+    /// }
+    /// ```
+    async fn append_bytes(&self, path: &Path, content: &[u8]) -> Result<()>;
+
+    // =========================================================================
+    // Metadata Operations (FR-1.4)
+    // =========================================================================
+
+    /// Checks whether a path exists on the filesystem.
+    ///
+    /// Implements FR-1.4.1: Check path existence.
+    ///
+    /// This method follows symbolic links. To check existence without following
+    /// symlinks, use [`symlink_metadata`][Self::symlink_metadata] and check for errors.
+    ///
+    /// Returns `false` if the path does not exist or if an error occurs during
+    /// the check (e.g., permission denied on a parent directory). This matches
+    /// the behavior of [`std::path::Path::exists`].
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn ensure_config_exists<FS: FileSystem>(fs: &FS) -> bool {
+    ///     fs.exists(Path::new("workspace.toml")).await
+    /// }
+    /// ```
+    async fn exists(&self, path: &Path) -> bool;
+
+    /// Checks whether a path points to a regular file.
+    ///
+    /// Implements FR-1.4.2: Check if path is a file.
+    ///
+    /// This method follows symbolic links. If the path is a symlink pointing to
+    /// a file, this returns `true`. Returns `false` if the path does not exist,
+    /// is a directory, or if an error occurs.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn validate_file<FS: FileSystem>(fs: &FS, path: &Path) -> bool {
+    ///     fs.is_file(path).await
+    /// }
+    /// ```
+    async fn is_file(&self, path: &Path) -> bool;
+
+    /// Checks whether a path points to a directory.
+    ///
+    /// Implements FR-1.4.3: Check if path is a directory.
+    ///
+    /// This method follows symbolic links. If the path is a symlink pointing to
+    /// a directory, this returns `true`. Returns `false` if the path does not
+    /// exist, is a file, or if an error occurs.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn validate_workspace<FS: FileSystem>(fs: &FS, path: &Path) -> bool {
+    ///     fs.is_dir(path).await
+    /// }
+    /// ```
+    async fn is_dir(&self, path: &Path) -> bool;
+
+    /// Checks whether a path points to a symbolic link.
+    ///
+    /// Implements FR-1.4.4: Check if path is a symlink.
+    ///
+    /// Unlike [`is_file`][Self::is_file] and [`is_dir`][Self::is_dir], this method
+    /// does **not** follow symbolic links. It checks the link itself, not its target.
+    /// Returns `false` if the path does not exist or if an error occurs.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn check_symlink<FS: FileSystem>(fs: &FS, path: &Path) -> bool {
+    ///     fs.is_symlink(path).await
+    /// }
+    /// ```
+    async fn is_symlink(&self, path: &Path) -> bool;
+
+    /// Retrieves metadata for a path, following symbolic links.
+    ///
+    /// Implements FR-1.4.5: Retrieve file metadata.
+    ///
+    /// If the path is a symbolic link, this returns metadata for the link's
+    /// target (the file or directory the link points to). To get metadata for
+    /// the link itself, use [`symlink_metadata`][Self::symlink_metadata].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn file_size<FS: FileSystem>(fs: &FS, path: &Path) -> workspace_fs::Result<u64> {
+    ///     let meta = fs.metadata(path).await?;
+    ///     Ok(meta.len())
+    /// }
+    /// ```
+    async fn metadata(&self, path: &Path) -> Result<Metadata>;
+
+    /// Retrieves metadata for a path without following symbolic links.
+    ///
+    /// Implements FR-1.4.6: Retrieve symlink metadata.
+    ///
+    /// If the path is a symbolic link, this returns metadata for the link itself,
+    /// not its target. The returned [`Metadata`] will report [`FileType::Symlink`](crate::FileType::Symlink).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn is_link<FS: FileSystem>(fs: &FS, path: &Path) -> workspace_fs::Result<bool> {
+    ///     let meta = fs.symlink_metadata(path).await?;
+    ///     Ok(meta.is_symlink())
+    /// }
+    /// ```
+    async fn symlink_metadata(&self, path: &Path) -> Result<Metadata>;
+
+    // =========================================================================
+    // Directory Operations (FR-1.5)
+    // =========================================================================
+
+    /// Creates a single directory.
+    ///
+    /// Implements FR-1.5.1: Create a directory.
+    ///
+    /// Creates the directory at the given path. The parent directory must already
+    /// exist. To create all intermediate directories, use
+    /// [`create_dir_all`][Self::create_dir_all].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The parent directory does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path already exists ([`Error::AlreadyExists`](crate::Error::AlreadyExists))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn setup_output<FS: FileSystem>(fs: &FS) -> workspace_fs::Result<()> {
+    ///     fs.create_dir(Path::new("output")).await
+    /// }
+    /// ```
+    async fn create_dir(&self, path: &Path) -> Result<()>;
+
+    /// Creates a directory and all its parent directories.
+    ///
+    /// Implements FR-1.5.2: Create directory tree.
+    ///
+    /// Creates the directory at the given path, including any missing parent
+    /// directories. If the directory already exists, this is a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - A component of the path exists but is not a directory
+    ///   ([`Error::NotADirectory`](crate::Error::NotADirectory))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn ensure_changeset_dir<FS: FileSystem>(fs: &FS) -> workspace_fs::Result<()> {
+    ///     fs.create_dir_all(Path::new(".changeset/fragments")).await
+    /// }
+    /// ```
+    async fn create_dir_all(&self, path: &Path) -> Result<()>;
+
+    /// Lists the entries of a directory.
+    ///
+    /// Implements FR-1.5.3: List directory contents.
+    ///
+    /// Returns all entries in the directory as a vector of [`DirEntry`] values.
+    /// The entries are not guaranteed to be in any particular order. This does
+    /// **not** recurse into subdirectories; use [`walk_dir`][Self::walk_dir]
+    /// for recursive traversal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is not a directory ([`Error::NotADirectory`](crate::Error::NotADirectory))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn list_packages<FS: FileSystem>(fs: &FS) -> workspace_fs::Result<Vec<String>> {
+    ///     let entries = fs.read_dir(Path::new("packages")).await?;
+    ///     Ok(entries.iter().filter(|e| e.file_type().is_dir()).map(|e| {
+    ///         e.file_name().to_string_lossy().into_owned()
+    ///     }).collect())
+    /// }
+    /// ```
+    async fn read_dir(&self, path: &Path) -> Result<Vec<DirEntry>>;
+
+    /// Removes an empty directory.
+    ///
+    /// Implements FR-1.5.4: Remove an empty directory.
+    ///
+    /// The directory must be empty. To remove a directory and all its contents,
+    /// use [`remove_dir_all`][Self::remove_dir_all].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is not a directory ([`Error::NotADirectory`](crate::Error::NotADirectory))
+    /// - The directory is not empty ([`Error::NotEmpty`](crate::Error::NotEmpty))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn cleanup_empty_dir<FS: FileSystem>(fs: &FS, path: &Path) -> workspace_fs::Result<()> {
+    ///     fs.remove_dir(path).await
+    /// }
+    /// ```
+    async fn remove_dir(&self, path: &Path) -> Result<()>;
+
+    /// Removes a directory and all its contents recursively.
+    ///
+    /// Implements FR-1.5.5: Remove directory tree.
+    ///
+    /// This removes the directory at the given path along with all files and
+    /// subdirectories it contains. Use with caution as this operation is
+    /// irreversible.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is not a directory ([`Error::NotADirectory`](crate::Error::NotADirectory))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn clean_build<FS: FileSystem>(fs: &FS) -> workspace_fs::Result<()> {
+    ///     fs.remove_dir_all(Path::new("target")).await
+    /// }
+    /// ```
+    async fn remove_dir_all(&self, path: &Path) -> Result<()>;
+
+    // =========================================================================
+    // File Operations (FR-1.6)
+    // =========================================================================
+
+    /// Removes a file.
+    ///
+    /// Implements FR-1.6.1: Remove a file.
+    ///
+    /// Removes the file at the given path. This does not follow symbolic links;
+    /// if the path is a symlink, the link itself is removed, not its target.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is a directory ([`Error::NotAFile`](crate::Error::NotAFile))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn remove_lockfile<FS: FileSystem>(fs: &FS) -> workspace_fs::Result<()> {
+    ///     fs.remove_file(Path::new(".lock")).await
+    /// }
+    /// ```
+    async fn remove_file(&self, path: &Path) -> Result<()>;
+
+    /// Copies a file from one path to another.
+    ///
+    /// Implements FR-1.6.2: Copy a file.
+    ///
+    /// Copies the contents and permissions of the file at `src` to `dst`. If `dst`
+    /// already exists, it is overwritten. The parent directory of `dst` must exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The source path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The source is a directory ([`Error::NotAFile`](crate::Error::NotAFile))
+    /// - The destination parent does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn backup_config<FS: FileSystem>(fs: &FS) -> workspace_fs::Result<()> {
+    ///     fs.copy_file(Path::new("config.json"), Path::new("config.json.bak")).await
+    /// }
+    /// ```
+    async fn copy_file(&self, src: &Path, dst: &Path) -> Result<()>;
+
+    /// Renames a file or directory.
+    ///
+    /// Implements FR-1.6.3: Rename/move a file or directory.
+    ///
+    /// Moves the filesystem entry from `src` to `dst`. This operation is atomic
+    /// on most platforms when the source and destination are on the same filesystem.
+    /// The parent directory of `dst` must exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The source path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The destination parent does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn finalize_changelog<FS: FileSystem>(fs: &FS) -> workspace_fs::Result<()> {
+    ///     fs.rename(
+    ///         Path::new("CHANGELOG.draft.md"),
+    ///         Path::new("CHANGELOG.md"),
+    ///     ).await
+    /// }
+    /// ```
+    async fn rename(&self, src: &Path, dst: &Path) -> Result<()>;
+
+    // =========================================================================
+    // Path Operations (FR-1.7)
+    // =========================================================================
+
+    /// Returns the canonical, absolute form of a path.
+    ///
+    /// Implements FR-1.7.1: Canonicalize a path.
+    ///
+    /// Resolves all symbolic links, `.`, and `..` components and returns the
+    /// resulting absolute path. The path must exist on the filesystem.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - A component of the path is not a directory ([`Error::NotADirectory`](crate::Error::NotADirectory))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn resolve_path<FS: FileSystem>(fs: &FS, path: &Path) -> workspace_fs::Result<std::path::PathBuf> {
+    ///     fs.canonicalize(path).await
+    /// }
+    /// ```
+    async fn canonicalize(&self, path: &Path) -> Result<PathBuf>;
+
+    /// Converts a relative path to an absolute path without I/O.
+    ///
+    /// Implements FR-1.7.2: Convert path to absolute form.
+    ///
+    /// Unlike [`canonicalize`][Self::canonicalize], this method does **not** access
+    /// the filesystem. It resolves `.` and `..` components and prepends the current
+    /// working directory if the path is relative, but does not follow symbolic links
+    /// or verify that the path exists.
+    ///
+    /// This is a **synchronous** method because it performs no I/O.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The current working directory cannot be determined ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// fn make_absolute<FS: FileSystem>(fs: &FS, path: &Path) -> workspace_fs::Result<std::path::PathBuf> {
+    ///     fs.absolute(path)
+    /// }
+    /// ```
+    fn absolute(&self, path: &Path) -> Result<PathBuf>;
+
+    // =========================================================================
+    // Symlink Operations (FR-1.8)
+    // =========================================================================
+
+    /// Reads the target path of a symbolic link.
+    ///
+    /// Implements FR-1.8.1: Read symbolic link target.
+    ///
+    /// Returns the path that the symbolic link points to. The returned path may
+    /// be relative or absolute, and may or may not exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is not a symbolic link ([`Error::Io`](crate::Error::Io))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn resolve_link<FS: FileSystem>(fs: &FS, path: &Path) -> workspace_fs::Result<std::path::PathBuf> {
+    ///     fs.read_link(path).await
+    /// }
+    /// ```
+    async fn read_link(&self, path: &Path) -> Result<PathBuf>;
+
+    // =========================================================================
+    // Directory Traversal (FR-1.9)
+    // =========================================================================
+
+    /// Recursively walks a directory tree and returns all entries.
+    ///
+    /// Implements FR-1.9.1: Recursive directory traversal.
+    ///
+    /// Returns all files, directories, and symbolic links found by recursively
+    /// traversing the given directory. The entries are returned in an unspecified
+    /// order. This is useful for operations that need to process entire directory
+    /// trees, such as finding all `package.json` files in a monorepo.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path does not exist ([`Error::NotFound`](crate::Error::NotFound))
+    /// - The path is not a directory ([`Error::NotADirectory`](crate::Error::NotADirectory))
+    /// - Permission is denied ([`Error::PermissionDenied`](crate::Error::PermissionDenied))
+    /// - An I/O error occurs ([`Error::Io`](crate::Error::Io))
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use workspace_fs::FileSystem;
+    /// use std::path::Path;
+    ///
+    /// async fn find_manifests<FS: FileSystem>(fs: &FS, root: &Path) -> workspace_fs::Result<Vec<std::path::PathBuf>> {
+    ///     let entries = fs.walk_dir(root).await?;
+    ///     Ok(entries.into_iter()
+    ///         .filter(|e| e.file_name() == "package.json")
+    ///         .map(|e| e.path().to_path_buf())
+    ///         .collect())
+    /// }
+    /// ```
+    async fn walk_dir(&self, path: &Path) -> Result<Vec<DirEntry>>;
+}
+
+// =============================================================================
+// Static Assertions
+// =============================================================================
+
+// Verify that FileSystem can be used as a generic bound with Send futures.
+// This ensures that `async fn foo<FS: FileSystem>(fs: &FS)` produces Send futures
+// when the implementation's futures are Send.
+const _: () = {
+    #[allow(unused)]
+    fn assert_usable_as_generic_bound<FS: FileSystem>() {}
+};

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,78 @@
+# Architecture Decision Records
+
+This document records significant architectural decisions for the workspace-node-tools project. Each decision is numbered and follows a consistent structure.
+
+---
+
+## ADR-001: Native async traits without dyn dispatch
+
+**Status:** Accepted  
+**Date:** 2026-02-07  
+**Scope:** `workspace-fs` crate (`FileSystem` trait)
+
+### Context
+
+The `FileSystem` trait in `workspace-fs` is the foundational abstraction for all filesystem operations across the workspace-node-tools ecosystem. The original design (per PRD revision 0) specified `#[async_trait]` from the `async-trait` crate to enable async methods in traits.
+
+However, the project targets:
+- **Rust Edition 2024** with `rust-version = "1.90.0"` MSRV
+- Native `async fn` in traits was stabilized in Rust 1.75
+- Return-type notation and `Send` bound inference improved through 1.85+
+- Edition 2024 captures all lifetimes in `impl Trait` return types, further simplifying async trait usage
+
+The `async-trait` crate works by desugaring `async fn` into `-> Pin<Box<dyn Future + Send>>`, which imposes:
+- A heap allocation per method call
+- A proc-macro compile-time dependency
+- Inability to benefit from future compiler optimizations to native async traits
+
+### Decision
+
+Use **native `async fn` in traits** for the `FileSystem` trait. Require `Send + Sync` as supertraits. Consumers use **generic bounds** (`<FS: FileSystem>` or `impl FileSystem`) rather than trait objects (`dyn FileSystem`).
+
+```rust
+// The trait definition
+pub trait FileSystem: Send + Sync {
+    async fn read_to_string(&self, path: &Path) -> Result<String>;
+    // ... 23 more methods
+}
+
+// Consumer pattern: generics, not dyn
+async fn read_config<FS: FileSystem>(fs: &FS, path: &Path) -> Result<String> {
+    fs.read_to_string(path).await
+}
+```
+
+### Rationale
+
+1. **Zero overhead**: No `Box::pin()` allocation per call. The compiler monomorphizes each generic instantiation.
+2. **No proc-macro dependency**: Removes `async-trait` from the dependency tree, reducing compile times and supply-chain surface.
+3. **Forward-compatible**: Aligns with the Rust project's direction. As async trait support matures (e.g., `dyn`-compatible async traits, trait-variant), this codebase benefits automatically.
+4. **Simpler error messages**: Native async traits produce clearer compiler diagnostics than proc-macro-generated code.
+
+### Consequences
+
+**Positive:**
+- Faster method dispatch (no heap allocation, no vtable)
+- Smaller dependency tree (no `async-trait`, `syn`, `quote` transitive deps)
+- Cleaner generated documentation (methods show as `async fn`, not `fn -> Pin<Box<...>>`)
+
+**Negative:**
+- Cannot use `dyn FileSystem` directly. This means:
+  - No heterogeneous collections of `Box<dyn FileSystem>`
+  - No runtime-polymorphic dispatch without a manual wrapper
+- If `dyn` dispatch is needed later, options include:
+  1. The [`trait-variant`](https://crates.io/crates/trait-variant) crate to auto-generate a dyn-compatible variant
+  2. A manual `DynFileSystem` wrapper struct that boxes futures internally
+  3. An enum dispatch pattern (`enum AnyFs { Real(RealFileSystem), Mock(MockFileSystem) }`)
+
+**Mitigations:**
+- The ecosystem currently has exactly two implementations (`RealFileSystem`, `MockFileSystem`), so `dyn` dispatch is not needed
+- All consumer code uses generics, which is idiomatic Rust and the recommended pattern for async traits
+- If a third-party plugin system is added later, enum dispatch or `trait-variant` can be introduced without changing the core trait
+
+### References
+
+- [Rust Blog: Async fn in traits](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html)
+- [Edition 2024 migration guide](https://doc.rust-lang.org/edition-guide/rust-2024/)
+- [trait-variant crate](https://crates.io/crates/trait-variant)
+- PRD Revision Appendix A (`crates/filesystem/PRD.md`): "Native async trait" revision


### PR DESCRIPTION
Define the core FileSystem trait using native async fn (no async-trait crate). The trait requires Send + Sync and provides complete filesystem abstraction: read/write ops, metadata queries, directory management, file operations, path resolution, symlink handling, and recursive directory traversal.

- traits.rs: 24 async methods with full doc comments and FR references
- lib.rs: enable pub use traits::FileSystem re-export
- docs/DECISIONS.md: ADR-001 documenting native async trait decision

Bead: workspace-node-tools-kzd.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * FileSystem trait is now publicly available, providing asynchronous operations for reading, writing, file metadata, and directory management.

* **Documentation**
  * Added architecture decision documentation for FileSystem trait design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->